### PR TITLE
Feature/authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>service-parent-pom</artifactId>
-		<version>1.5.0-SNAPSHOT</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 	<properties>
 		<jdk.version>1.8</jdk.version>

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -1,16 +1,21 @@
 package life.qbic.controller
 
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.context.annotation.Parameter
 import io.micronaut.http.HttpResponse
+import io.micronaut.security.annotation.Secured
+import life.qbic.micronaututils.auth.Authentication
 
 import javax.inject.Inject
 import life.qbic.datamodel.services.Contact
 import life.qbic.datamodel.services.Location
 import life.qbic.service.ILocationService
 
+@Requires(beans = Authentication.class)
+@Secured("isAuthenticated()")
 @Controller("/locations")
 class LocationsController {
 

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -7,15 +7,17 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.context.annotation.Parameter
 import io.micronaut.http.HttpResponse
 import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
 import life.qbic.micronaututils.auth.Authentication
 
+import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
 import life.qbic.datamodel.services.Contact
 import life.qbic.datamodel.services.Location
 import life.qbic.service.ILocationService
 
 @Requires(beans = Authentication.class)
-@Secured("isAuthenticated()")
+@Secured(SecurityRule.IS_AUTHENTICATED)
 @Controller("/locations")
 class LocationsController {
 
@@ -27,6 +29,7 @@ class LocationsController {
   }
 
   @Get(uri = "/contacts/{email}", produces = MediaType.APPLICATION_JSON)
+  @RolesAllowed(["READER", "WRITER"])
   HttpResponse<Contact> contacts(@Parameter('email') String email){
     if(!RegExValidator.isValidMail(email)) {
       HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
@@ -45,6 +48,7 @@ class LocationsController {
   }
 
   @Get(uri = "/{contact_email}", produces = MediaType.APPLICATION_JSON)
+  @RolesAllowed(["READER", "WRITER"])
   HttpResponse<List<Location>> locations(@Parameter('contact_email') String contact_email){
     if(!RegExValidator.isValidMail(contact_email)) {
       HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
@@ -56,8 +60,9 @@ class LocationsController {
   }
 
   @Get(uri = "/", produces = MediaType.APPLICATION_JSON)
+  @RolesAllowed(["READER", "WRITER"])
   HttpResponse<List<Location>> listLocations() {
-    List<Location> res = locService.listLocations();
+    List<Location> res = locService.listLocations()
     return HttpResponse.ok(res)
   }
 }

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -4,17 +4,21 @@ import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Body
-import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import life.qbic.micronaututils.auth.Authentication
 
+import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
 import life.qbic.datamodel.services.*
 import life.qbic.service.ISampleService
 
+@Requires(beans = Authentication.class)
+@Secured(SecurityRule.IS_AUTHENTICATED)
 @Controller("/samples")
 class SamplesController {
 
@@ -25,7 +29,9 @@ class SamplesController {
     this.sampleService = sampleService
   }
 
-  @Get(uri = "/{sampleId}", produces = MediaType.APPLICATION_JSON) HttpResponse<Sample> sample(@Parameter('sampleId') String code) {
+  @Get(uri = "/{sampleId}", produces = MediaType.APPLICATION_JSON)
+  @RolesAllowed([ "READER", "WRITER"])
+  HttpResponse<Sample> sample(@Parameter('sampleId') String code) {
     if(!RegExValidator.isValidSampleCode(code)) {
       return HttpResponse.badRequest("Not a valid sample code!");
     } else {
@@ -39,6 +45,7 @@ class SamplesController {
   }
 
   @Post("/{sampleId}/currentLocation/")
+  @RolesAllowed("WRITER")
   HttpResponse<Location> newLocation(@Parameter('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.badRequest("Not a valid sample code!");
@@ -54,6 +61,7 @@ class SamplesController {
    * @return
    */
   @Put("/{sampleId}/currentLocation/")
+  @RolesAllowed("WRITER")
   HttpResponse<Location> updateLocation(@Parameter('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.badRequest("Not a valid sample code!");
@@ -63,6 +71,7 @@ class SamplesController {
   }
 
   @Put("/{sampleId}/currentLocation/{status}")
+  @RolesAllowed("WRITER")
   HttpResponse sampleStatus(@Parameter('sampleId') String sampleId, @Parameter('status') Status status) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.badRequest("Not a valid sample code!");

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,3 +7,5 @@ datasources:
             username: testuser
             driver-class-name: org.hsqldb.jdbc.JDBCDriver
             password: ""
+userroles:
+    config: "src/test/resources/userroles.yml"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,5 +9,7 @@ datasources:
         username: ${tr-db-user}
         password: ${tr-db-pwd}
         driverClassName: org.mariadb.jdbc.Driver
+userroles:
+    config: ${domain-userroles:/etc/micronaut.d/userroles.yml}
 database:
     name: ${tr-db-name}

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -87,7 +87,7 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email, "")
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/"+email)
+    HttpRequest request = HttpRequest.GET("/locations/"+email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     assertEquals(arr.size(), 1)
@@ -100,7 +100,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedLocationsMail() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/justreadtheinstructions")
+    HttpRequest request = HttpRequest.GET("/locations/justreadtheinstructions").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -122,7 +122,7 @@ class LocationsControllerIntegrationTest {
     int personID3 = db.addPerson("u3", "Markus", "Meier", "abc3@bla.de", "")
     int locationID3 = db.addLocationForPerson("loc3", "street 3", "france", 0, personID3)
 
-    HttpRequest request = HttpRequest.GET("/locations/")
+    HttpRequest request = HttpRequest.GET("/locations/").basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     assertEquals(arr.size(), 3)
@@ -138,7 +138,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testEmptyLocations() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/")
+    HttpRequest request = HttpRequest.GET("/locations/").basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     assert(arr.empty)
@@ -146,7 +146,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testNonExistingContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/ian.banks@limitingfactor.com")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/ian.banks@limitingfactor.com").basicAuth("servicewriter", "123456!")
     String error = "";
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -169,7 +169,7 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email, "")
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/contacts/"+email)
+    HttpRequest request = HttpRequest.GET("/locations/contacts/"+email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     assertNotNull(body)
@@ -186,7 +186,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -84,7 +84,7 @@ class SamplesControllerIntegrationTest {
 
   @Test
   void testMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.GET("/samples/wrong")
+    HttpRequest request = HttpRequest.GET("/samples/wrong").basicAuth("servicewriter", "123456!")
     String error = "";
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -118,7 +118,7 @@ class SamplesControllerIntegrationTest {
 
     db.addSampleWithHistory(validCode1, currentLocation, currentPerson, pastLocations, pastPersons)
 
-    HttpRequest request = HttpRequest.GET("/samples/"+validCode1)
+    HttpRequest request = HttpRequest.GET("/samples/"+validCode1).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
 
     Sample s = mapper.readValue(body, Sample.class);
@@ -144,7 +144,7 @@ class SamplesControllerIntegrationTest {
 
 
     for(int i = 0; i < 40;i++) {
-      HttpRequest request = HttpRequest.GET("/samples/QTRAK005A9")
+      HttpRequest request = HttpRequest.GET("/samples/QTRAK005A9").basicAuth("servicewriter", "123456!")
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
@@ -169,7 +169,7 @@ class SamplesControllerIntegrationTest {
     db.addLocation(l2)
 
     for(String code : codes) {
-      HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l1)
+      HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l1).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
       assertEquals(response.status.getCode(), 200)
 
@@ -182,7 +182,7 @@ class SamplesControllerIntegrationTest {
     }
 
     for(String code : codes) {
-      HttpRequest request = HttpRequest.GET("/samples/"+code)
+      HttpRequest request = HttpRequest.GET("/samples/"+code).basicAuth("servicewriter", "123456!")
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
@@ -196,7 +196,7 @@ class SamplesControllerIntegrationTest {
     }
 
     for(String code : codes) {
-      HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l2)
+      HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l2).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
       assertEquals(response.status.getCode(), 200)
 
@@ -209,7 +209,7 @@ class SamplesControllerIntegrationTest {
     }
 
     for(String code : codes) {
-      HttpRequest request = HttpRequest.GET("/samples/"+code)
+      HttpRequest request = HttpRequest.GET("/samples/"+code).basicAuth("servicewriter", "123456!")
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
@@ -225,7 +225,7 @@ class SamplesControllerIntegrationTest {
 
   @Test
   void testMissingSample() throws Exception {
-    HttpRequest request = HttpRequest.GET("/samples/"+missingValidCode)
+    HttpRequest request = HttpRequest.GET("/samples/"+missingValidCode).basicAuth("servicewriter", "123456!")
     String error = "";
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -238,7 +238,7 @@ class SamplesControllerIntegrationTest {
 
   @Test
   void testStatusMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","")
+    HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -259,7 +259,7 @@ class SamplesControllerIntegrationTest {
 
     db.addSampleWithHistory(validCode2, currentLocation, currentPerson, new ArrayList<>(), new ArrayList<>())
 
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","")
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     assertEquals(body, "Sample status updated.")
 
@@ -269,11 +269,11 @@ class SamplesControllerIntegrationTest {
     json = json.get("current_location")
     assertEquals(json.get("sample_status"), Status.WAITING.toString());
 
-    request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","")
+    request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","").basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     assertEquals(body, "Sample status updated.")
 
-    request = HttpRequest.GET("/samples/"+validCode2)
+    request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     json = new JSONObject(body);
     json = json.get("current_location")
@@ -291,7 +291,7 @@ class SamplesControllerIntegrationTest {
 
     db.addSampleWithHistory(validCode3, currentLocation, currentPerson, new ArrayList<>(), new ArrayList<>())
 
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode3+"/currentLocation/TIRED","")
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode3+"/currentLocation/TIRED","").basicAuth("servicewriter", "123456!")
     boolean res = false
     try {
       String body = client.toBlocking().retrieve(request)
@@ -304,7 +304,7 @@ class SamplesControllerIntegrationTest {
   @Test
   void testStatusNoSample() throws Exception {
     String code = "QNONE001AC"
-    HttpRequest request = HttpRequest.PUT("/samples/"+code+"/currentLocation/WAITING","")
+    HttpRequest request = HttpRequest.PUT("/samples/"+code+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -321,7 +321,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 11", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: "some@person.de", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
 
-    HttpRequest request = HttpRequest.POST("/samples/"+malformedCode+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.POST("/samples/"+malformedCode+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -356,7 +356,7 @@ class SamplesControllerIntegrationTest {
     //    db.addSample(validCode4, locID)
     db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email, "123")
 
-    HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
     assertEquals(response.status.getCode(), 200)
 
@@ -372,7 +372,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 1", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     db.addSampleWithHistory(validCode5, location, currentPerson, new ArrayList<>(), new ArrayList<>())
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
     assertEquals(response.status.getCode(), 200)
 
@@ -382,7 +382,7 @@ class SamplesControllerIntegrationTest {
 
     d = new java.sql.Date(new Date().getTime());
     location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
-    request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location)
+    request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     response = client.toBlocking().exchange(request)
     assertEquals(response.status.getCode(), 200)
 
@@ -397,7 +397,7 @@ class SamplesControllerIntegrationTest {
     Person currentPerson = new Person("some", "person",email)
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 2", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
-    HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     int stat = -1
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -414,7 +414,7 @@ class SamplesControllerIntegrationTest {
     Person currentPerson = new Person("some", "person",email)
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 3", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     int stat = -1
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -431,7 +431,7 @@ class SamplesControllerIntegrationTest {
     Person currentPerson = new Person("some", "person",email)
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 4", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
-    HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     int stat = -1
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -448,7 +448,7 @@ class SamplesControllerIntegrationTest {
     Person currentPerson = new Person("some", "person",email)
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 5", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location)
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     int stat = -1
     try {
       HttpResponse response = client.toBlocking().exchange(request)

--- a/src/test/resources/userroles.yml
+++ b/src/test/resources/userroles.yml
@@ -1,0 +1,11 @@
+---
+servicereader:
+  token: 123!
+  roles:
+    - READER
+servicewriter:
+  token: 123456!
+  roles:
+    - READER
+    - WRITER
+...


### PR DESCRIPTION
Enables basic authentication for the sample tracking service.

User roles and credentials must be passed to the service in a `userroles.yml`, which is by default expected to be in `/etc/micronaut.d/userroles.yml`, but the path can be configured by setting the property in the `application.yml` or setting an environment variable `$DOMAIN_USERROLES`.

```
userroles:
    config: ${domain-userroles:/etc/micronaut.d/userroles.yml}
```