### PR TITLE
change location endpoints to make query by email or username possible

### DIFF
--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -10,12 +10,15 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import life.qbic.micronaututils.auth.Authentication
 
+import groovy.util.logging.Log4j2
+import javax.annotation.Nullable
 import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
 import life.qbic.datamodel.services.Contact
 import life.qbic.datamodel.services.Location
 import life.qbic.service.ILocationService
 
+@Log4j2
 @Requires(beans = Authentication.class)
 @Secured(SecurityRule.IS_AUTHENTICATED)
 @Controller("/locations")
@@ -28,41 +31,59 @@ class LocationsController {
     this.locService = locService
   }
 
-  @Get(uri = "/contacts/{email}", produces = MediaType.APPLICATION_JSON)
+  @Get(uri = "/contacts{?username,email}", produces = MediaType.APPLICATION_JSON)
   @RolesAllowed(["READER", "WRITER"])
-  HttpResponse<Contact> contacts(@Parameter('email') String email){
-    if(!RegExValidator.isValidMail(email)) {
-      HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
-      return res
-    } else {
-      Contact contact = locService.searchPersonByEmail(email);
+  HttpResponse<Contact> contacts(@Nullable String username, @Nullable String email){
+    if(username && email) {
+      log.warn("E-mail address and username received. Only e-mail address will be used to search for contact.");
+    }
+    if(email) {
+      if(!RegExValidator.isValidMail(email)) {
+        HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
+        return res
+      } else {
+        Contact contact = locService.searchPersonByEmail(email)
+        if(contact!=null) {
+          HttpResponse<Contact> res = HttpResponse.ok(contact)
+          return res
+        }
+        else {
+          HttpResponse<Contact> res = HttpResponse.notFound("Email address was not found in the system!")
+          return res
+        }
+      }
+    }
+    if(username) {
+      Contact contact = locService.searchPersonByUsername(username)
       if(contact!=null) {
         HttpResponse<Contact> res = HttpResponse.ok(contact)
         return res
       }
       else {
-        HttpResponse<Contact> res = HttpResponse.notFound("Email address was not found in the system!")
+        HttpResponse<Contact> res = HttpResponse.notFound("Username was not found in the system!")
         return res
       }
     }
+    return HttpResponse.badRequest("E-mail address or username must be specified!")
   }
 
-  @Get(uri = "/{contact_email}", produces = MediaType.APPLICATION_JSON)
+  @Get(uri = '{?username,email}', produces = MediaType.APPLICATION_JSON)
   @RolesAllowed(["READER", "WRITER"])
-  HttpResponse<List<Location>> locations(@Parameter('contact_email') String contact_email){
-    if(!RegExValidator.isValidMail(contact_email)) {
-      HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
-      return res
-    } else {
-      List<Location> locations = locService.getLocationsForEmail(contact_email);
-      return HttpResponse.ok(locations)
+  HttpResponse<List<Location>> listLocations(@Nullable String username, @Nullable String email) {
+    List<Location> res = new ArrayList<>()
+    if(!username && !email) {
+      res = locService.listLocations()
+      return HttpResponse.ok(res)
     }
-  }
-
-  @Get(uri = "/", produces = MediaType.APPLICATION_JSON)
-  @RolesAllowed(["READER", "WRITER"])
-  HttpResponse<List<Location>> listLocations() {
-    List<Location> res = locService.listLocations()
+    if(username) {
+      res.addAll(locService.getLocationsForUsername(username))
+    }
+    if(email) {
+      if(!RegExValidator.isValidMail(email)) {
+        return HttpResponse.badRequest("Not a valid email address!")
+      }
+      res.addAll(locService.getLocationsForEmail(email))
+    }
     return HttpResponse.ok(res)
   }
 }

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -70,20 +70,20 @@ class LocationsController {
   @Get(uri = '{?username,email}', produces = MediaType.APPLICATION_JSON)
   @RolesAllowed(["READER", "WRITER"])
   HttpResponse<List<Location>> listLocations(@Nullable String username, @Nullable String email) {
-    List<Location> res = new ArrayList<>()
+    Set<Location> locationSet = new ArrayList<>()
     if(!username && !email) {
-      res = locService.listLocations()
-      return HttpResponse.ok(res)
+      return HttpResponse.ok(locService.listLocations())
     }
     if(username) {
-      res.addAll(locService.getLocationsForUsername(username))
+      locationSet.addAll(locService.getLocationsForUsername(username))
     }
     if(email) {
       if(!RegExValidator.isValidMail(email)) {
         return HttpResponse.badRequest("Not a valid email address!")
       }
-      res.addAll(locService.getLocationsForEmail(email))
+      locationSet.addAll(locService.getLocationsForEmail(email))
     }
+    List<Location> res = new ArrayList<>(locationSet)
     return HttpResponse.ok(res)
   }
 }

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -9,7 +9,11 @@ interface IQueryService {
 
   Contact searchPersonByEmail(String email)
   
+  Contact searchPersonByUsername(String username)
+  
   List<Location> listLocations()
+  
+  List<Location> getLocationsForUsername(String username)
   
   List<Location> getLocationsForEmail(String email)
 

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -9,7 +9,11 @@ interface ILocationService {
 
   Contact searchPersonByEmail(String email)
   
+  Contact searchPersonByUsername(String username)
+  
   List<Location> listLocations()
   
   List<Location> getLocationsForEmail(String email)
+  
+  List<Location> getLocationsForUsername(String username)
 }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -19,11 +19,17 @@ class LocationServiceCenter implements ILocationService {
   @Inject LocationServiceCenter(IQueryService database) {
     this.database = database
   }
-
+  
   @Override
   Contact searchPersonByEmail(String email) {
     log.info "Searching for person with e-mail "+email
     return database.searchPersonByEmail(email)
+  }
+  
+  @Override
+  Contact searchPersonByUsername(String username) {
+    log.info "Searching for person with username "+username
+    return database.searchPersonByUsername(username)
   }
 
   @Override
@@ -31,10 +37,16 @@ class LocationServiceCenter implements ILocationService {
     log.info "Listing all known locations"
     return database.listLocations();
   }
-
+  
   @Override
   List<Location> getLocationsForEmail(String email) {
     log.info "Listing all known locations for person with e-mail "+email
     return database.getLocationsForEmail(email);
+  }
+  
+  @Override
+  List<Location> getLocationsForUsername(String username) {
+    log.info "Listing all known locations for person with username "+username
+    return database.getLocationsForUsername(username);
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -87,7 +87,7 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email, "")
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/"+email).basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations?email="+email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     assertEquals(arr.size(), 1)
@@ -100,7 +100,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedLocationsMail() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/justreadtheinstructions").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations?email=justreadtheinstructions").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -147,7 +147,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testNonExistingContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/ian.banks@limitingfactor.com").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts?email=ian.banks@limitingfactor.com").basicAuth("servicewriter", "123456!")
     String error = "";
     try {
       HttpResponse response = client.toBlocking().exchange(request)
@@ -170,7 +170,7 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email, "")
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/contacts/"+email).basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts?email="+email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     assertNotNull(body)
@@ -187,7 +187,7 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts?email=justreadtheinstructions").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
       HttpResponse response = client.toBlocking().exchange(request)

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -35,12 +35,18 @@ class LocationsControllerTest {
 
   @Before
   void setupMock() {
-    locations = new LocationsController(new LocationServiceCenter(new QueryMock()));
+    locations = new LocationsController(new LocationServiceCenter(new QueryMock()))
+  }
+
+  @Test
+  void testContactTwoParameters() throws Exception {
+    HttpResponse<Contact> response = locations.contacts("player", "wrong@wrong.de")
+    assertEquals(response.getStatus().getCode(),404)
   }
 
   @Test
   void testNonExistingContact() throws Exception {
-    HttpResponse<Contact> response = locations.contacts("ian.banks@limitingfactor.com")
+    HttpResponse<Contact> response = locations.contacts(null, "wrong@wrong.de")
     assertEquals(response.getStatus().getCode(),404)
   }
 
@@ -54,7 +60,7 @@ class LocationsControllerTest {
     int zip = 0
     String country = "Chiark"
 
-    HttpResponse response = locations.contacts(email)
+    HttpResponse response = locations.contacts(null, email)
     assertEquals(response.getStatus().getCode(),200)
     Contact c = response.body.orElse(null)
 
@@ -68,31 +74,53 @@ class LocationsControllerTest {
   }
 
   @Test
-  void testMalformedContact() throws Exception {
-    HttpResponse response = locations.contacts("justreadtheinstructions")
+  void testContactUsername() throws Exception {
+    String email = "jernau@hassease.gv"
+    String first = "Jernau"
+    String last ="Gurgeh"
+    String affName = "Gevantsa"
+    String street = "Hassease"
+    int zip = 0
+    String country = "Chiark"
+
+    HttpResponse response = locations.contacts("player", null)
+    assertEquals(response.getStatus().getCode(),200)
+    Contact c = response.body.orElse(null)
+
+    assertEquals(c.fullName,first+" "+last)
+    assertEquals(c.email,email)
+    Address address = c.address
+    assertEquals(address.affiliation,affName)
+    assertEquals(address.street,street)
+    assertEquals(address.zipCode,zip)
+    assertEquals(address.country,country)
+  }
+
+  @Test
+  void testMalformedContactMail() throws Exception {
+    HttpResponse response = locations.contacts(null, "justreadtheinstructions")
     assertEquals(response.getStatus().getCode(), 400)
   }
-  
+
   @Test
   void testLocationsMail() throws Exception {
-    HttpResponse response = locations.locations("right@right.de")
+    HttpResponse response = locations.listLocations(null, "right@right.de")
     assertEquals(response.getStatus().getCode(), 200)
     List<Location> loc = response.body.orElse(null)
     assertEquals(loc.size(),1)
   }
-  
+
   @Test
   void testMalformedLocationsMail() throws Exception {
-    HttpResponse response = locations.locations("justreadtheinstructions")
+    HttpResponse response = locations.listLocations(null, "justreadtheinstructions")
     assertEquals(response.getStatus().getCode(), 400)
   }
-  
+
   @Test
   void testLocations() throws Exception {
-    HttpResponse response = locations.listLocations()
+    HttpResponse response = locations.listLocations(null, null)
     assertEquals(response.getStatus().getCode(), 200)
     List<Location> loc = response.body.orElse(null)
     assertEquals(loc.size(),2)
   }
-
 }

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -48,11 +48,21 @@ class QueryMock implements IQueryService {
     return null
   }
 
-//  @Override
+  Contact searchPersonByUsername(String username) {
+    String user = "player"
+    if(username.equals(user)) {
+      String mail = "jernau@hassease.gv"
+      Address adr = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+      return new Contact(fullName: "Jernau Gurgeh", email: mail, address: adr)
+    }
+    return null
+  }
+
+  //  @Override
   public Sample searchSample(String sampleId) {
     String code = "QABCD001A0"
     if(sampleId.equals(code)) {
-      
+
       Date d = new java.sql.Date(new Date().getTime());
 
       Address adr1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
@@ -67,7 +77,7 @@ class QueryMock implements IQueryService {
     return null
   }
 
-//  @Override
+  //  @Override
   public boolean updateSampleStatus(String sampleId, Status status) {
     return status!=null
   }
@@ -75,7 +85,7 @@ class QueryMock implements IQueryService {
   @Override
   List<Location> listLocations() {
     Date d = new java.sql.Date(new Date().getTime());
-    
+
     Address adr1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
     Address adr2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
     List<Location> locs = new ArrayList<>()
@@ -88,19 +98,33 @@ class QueryMock implements IQueryService {
   @Override
   List<Location> getLocationsForEmail(String email) {
     Date d = new java.sql.Date(new Date().getTime());
-    
+
     Address adr1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
     Address adr2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
     List<Location> locs = new ArrayList<>()
     Location loc1 = new Location(name: "Current", responsiblePerson: "Current Person", responsibleEmail: "wrong@wrong.de", address: adr1, status: Status.WAITING, arrivalDate: d, forwardDate: d)
     locs.add(new Location(name: "Past", responsiblePerson: "Old Person", responsibleEmail: "right@right.de", address: adr2, status: Status.PROCESSED, arrivalDate: d, forwardDate: d))
     locs.add(loc1)
-    
+
     List<Location> res = new ArrayList<Location>()
     for(Location l : locs) {
       if(l.responsibleEmail.equals(email))
         res.add(l)
     }
     return res;
+  }
+
+  @Override
+  List<Location> getLocationsForUsername(String username) {
+    Date d = new java.sql.Date(new Date().getTime());
+
+    Address adr1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+    Address adr2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+    List<Location> locs = new ArrayList<>()
+    Location loc1 = new Location(name: "Current", responsiblePerson: "Current Person", responsibleEmail: "wrong@wrong.de", address: adr1, status: Status.WAITING, arrivalDate: d, forwardDate: d)
+    locs.add(new Location(name: "Past", responsiblePerson: "Old Person", responsibleEmail: "right@right.de", address: adr2, status: Status.PROCESSED, arrivalDate: d, forwardDate: d))
+    //    locs.add(loc1)
+
+    return locs;
   }
 }


### PR DESCRIPTION
Changes location queries that expected an e-mail address to also work with a username. Arguments are named and optional now.
- Calling the "locations" endpoint without arguments will return all possible locations
- Calling it with e-mail/username will return locations associated with the person having that email address/username
- Calling it with both will return the merged set of locations for this e-mail and username

For the "locations/contact" endpoint, one contact is returned, if an existing e-mail or username is used for the query.

In both cases the e-mail address takes precedence, so in the contact endpoint the username is ignored, if an e-mail address is provided.