### PR TITLE
Deprecate email dependant methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+- Add missing JavaDoc (Issue #15)
+- the `/{email}` endpoint now searches by the newly introduced `user_id` instead.
+    This is no change in the behaviour as of now since they are identical as of now.
 ## Release 1.0.4
 
 - Append new location to history even if old location is the same as

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -81,6 +81,7 @@ class LocationsController {
           content = @Content(
                   mediaType = "application/json",
                   schema = @Schema(implementation = Location.class)))
+  @ApiResponse(responseCode = "400", description = "Bad Request")
   @ApiResponse(responseCode = "500", description = "Unexpected error during execution")
   @RolesAllowed(["READER"])
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
@@ -88,12 +89,14 @@ class LocationsController {
     List<Location> searchResult
     try {
       searchResult = locService.getLocationsForPerson(userId)
-      return HttpResponse.ok(searchResult)
+      response = HttpResponse.ok(searchResult)
     } catch (IllegalArgumentException ignored) {
-      return HttpResponse.badRequest()
+      response = HttpResponse.status(HttpStatus.BAD_REQUEST, ignored.getMessage())
     } catch (Exception ignored) {
-      return HttpResponse.serverError()
+      response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, ignored.getMessage())
     }
+    return response
+    
   }
 
   @Get(uri = "/", produces = MediaType.APPLICATION_JSON)

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -59,13 +59,14 @@ class LocationsController {
       HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
       return res
     } else {
-      Contact contact = locService.searchPersonByEmail(email);
+      Contact contact = locService.searchPersonByEmail(email)
       if(contact!=null) {
         HttpResponse<Contact> res = HttpResponse.ok(contact)
         return res
       }
       else {
-        HttpResponse<Contact> res = HttpResponse.notFound("Email address was not found in the system!")
+        HttpResponse<Contact> res = HttpResponse.notFound(contact)
+        res.reason = "Email address was not found in the system!"
         return res
       }
     }

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -79,12 +79,17 @@ class LocationsController {
           content = @Content(
                   mediaType = "application/json",
                   schema = @Schema(implementation = Location.class)))
-  @ApiResponse(responseCode = "400", description = "Invalid user")
-  @ApiResponse(responseCode = "401", description = "Unauthorized access")
-  @ApiResponse(responseCode = "404", description = "Location not found")
-  @RolesAllowed(["READER", "WRITER"])
-  HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId){
-      return locService.getLocationsForPerson(userId)
+  @ApiResponse(responseCode = "500", description = "Unexpected error during execution")
+  @RolesAllowed(["READER"])
+  HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
+    HttpResponse<List<Location>> response
+    List<Location> searchResult
+    try {
+      searchResult = locService.getLocationsForPerson(userId)
+      return HttpResponse.ok(searchResult)
+    } catch (Exception ignored) {
+      return HttpResponse.serverError()
+    }
   }
 
   @Get(uri = "/", produces = MediaType.APPLICATION_JSON)

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -43,10 +43,10 @@ interface IQueryService {
    * List all locations attached to a person with the provided identifier
    * Currently one email address is used as identifier for a person in the system
    * @param identifier the identifier for a person
-   * @return HttpResponse containing a list of locations for the given person, if the query was successfull
+   * @return a list of locations for the given person, if the query was successful
    * @since 1.1.0
    */
-  HttpResponse getLocationsForPerson(String identifier)
+  List<Location> getLocationsForPerson(String identifier)
 
   /**
    * Adds a new location for a provided sample code to the database, signifying the forwarding of that sample to that location.

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -15,7 +15,10 @@ interface IQueryService {
    * @param email email address
    * @return Contact object of the contact with the provided email address
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and might be removed in the future.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   Contact searchPersonByEmail(String email)
 
   /**
@@ -30,8 +33,20 @@ interface IQueryService {
    * @param email email address
    * @return list of Location objects
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and will be removed in the future. {@link #getLocationsForPerson} should be used instead.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   List<Location> getLocationsForEmail(String email)
+
+  /**
+   * List all locations attached to a person with the provided identifier
+   * Currently one email address is used as identifier for a person in the system
+   * @param identifier the identifier for a person
+   * @return an Optional containing a list of locations if any could be found
+   * @since 1.1.0
+   */
+  Optional<List<Location>> getLocationsForPerson(String identifier)
 
   /**
    * Adds a new location for a provided sample code to the database, signifying the forwarding of that sample to that location.

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -43,10 +43,10 @@ interface IQueryService {
    * List all locations attached to a person with the provided identifier
    * Currently one email address is used as identifier for a person in the system
    * @param identifier the identifier for a person
-   * @return an Optional containing a list of locations if any could be found
+   * @return a list of locations for the given person
    * @since 1.1.0
    */
-  Optional<List<Location>> getLocationsForPerson(String identifier)
+  List<Location> getLocationsForPerson(String identifier)
 
   /**
    * Adds a new location for a provided sample code to the database, signifying the forwarding of that sample to that location.

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -140,10 +140,10 @@ class MariaDBManager implements IQueryService {
   }
 
   @Override
-  Optional<List<Location>> getLocationsForPerson(String identifier) {
-    List<Location> locations = null
+  List<Location> getLocationsForPerson(String identifier) {
     throw new RuntimeException("Method not implemented.")
-    return Optional.ofNullable(locations)
+    List<Location> locations = new ArrayList<>()
+    return locations
   }
 
   List<Location> listLocations() {

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -109,7 +109,7 @@ class MariaDBManager implements IQueryService {
       GroovyRowResult res = results.get(0)
       int id = res.get("id")
       String first = res.get("first_name")
-      String last = res.get("family_name")
+      String last = res.get("last_name")
       Address adr = getAddressByPerson(id, sql)
       contact = new Contact(fullName: first + " " + last, email: email, address: adr)
     }
@@ -135,9 +135,14 @@ class MariaDBManager implements IQueryService {
       sql = new Sql(this.dataSource)
       sql.withTransaction {
         Map userInformation = getPersonById(identifier, sql)
+        log.error("JONSADANSDJNASDN")
+        log.error(userInformation)
+        
         // find locations for user
         int userDbId = userInformation.get("id") as int
-        String query = "SELECT name FROM locations INNER JOIN persons_locations ON id=location_id WHERE person_id = '$userDbId';"
+        String query = "SELECT * FROM locations INNER JOIN persons_locations ON id=location_id WHERE person_id = $userDbId;"
+        log.error("query:")
+        log.error(query)
         List<GroovyRowResult> rowResults = sql.rows(query)
         rowResults.each { locations.add(parseLocationFromMap(it)) }
       }
@@ -156,7 +161,7 @@ class MariaDBManager implements IQueryService {
    *     <ul>
    *         <li><code>country</code></li>
    *         <li><code>email</code></li>
-   *         <li><code>family_name</code></li>
+   *         <li><code>last_name</code></li>
    *         <li><code>first_name</code></li>
    *         <li><code>name</code></li>
    *         <li><code>street</code></li>
@@ -166,7 +171,7 @@ class MariaDBManager implements IQueryService {
    */
   private static Location parseLocationFromMap(Map input) {
 
-    Collection<String> expectedKeys = ["name", "street", "zip_code", "country", "first_name", "family_name", "email"]
+    Collection<String> expectedKeys = ["name", "street", "zip_code", "country", "first_name", "last_name", "email"]
     if (!input.keySet().containsAll(expectedKeys.each {it.toUpperCase()})) {
       log.info(input.keySet())
       throw new IllegalArgumentException ("The provided input did not provide all expected keys.")
@@ -180,7 +185,7 @@ class MariaDBManager implements IQueryService {
     Address address = new Address(affiliation: name, street: street, zipCode: zip, country: country)
     //Person
     String first = input.get("first_name")
-    String last = input.get("family_name")
+    String last = input.get("last_name")
     String mail = input.get("email")
     return new Location(name: name, responsiblePerson: first+" "+last, responsibleEmail: mail, address: address);
   }
@@ -201,7 +206,7 @@ class MariaDBManager implements IQueryService {
       Address address = new Address(affiliation: name, street: street, zipCode: zip, country: country)
       //Person
       String first = rs.get("first_name")
-      String last = rs.get("family_name")
+      String last = rs.get("last_name")
       String mail = rs.get("email")
       Location l = new Location(name: name, responsiblePerson: first+" "+last, responsibleEmail: mail, address: address);
       locs.add(l)
@@ -402,7 +407,7 @@ class MariaDBManager implements IQueryService {
         GroovyRowResult rs = results.get(0)
         //        logger.info("email found!");
         String firstName = rs.get("first_name")
-        String lastName = rs.get("family_name")
+        String lastName = rs.get("last_name")
         String email = rs.get("email")
         res = new Person(firstName, lastName, email)
       }
@@ -476,7 +481,11 @@ class MariaDBManager implements IQueryService {
    */
   private static Map<String, ?> getPersonById(String identifier, Sql sql) {
     String query = "SELECT * FROM $PERSONS_TABLE WHERE user_id = '$identifier'"
+    log.error(query)
     List<GroovyRowResult> rowResults = sql.rows(query)
+    log.error("LJANSDANDS")
+    log.error(rowResults)
+    log.error("LJANSDANDS")
     if (rowResults.size() == 1) {
       return rowResults.first() as Map
     } else {

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -128,10 +128,9 @@ class MariaDBManager implements IQueryService {
   }
 
   @Override
-  HttpResponse<List<Location>> getLocationsForPerson(String identifier) {
+  List<Location> getLocationsForPerson(String identifier) {
     Sql sql = null
     List<Location> locations = new ArrayList<>()
-    HttpResponse<List<Location>> response = HttpResponse.ok(locations)
     try {
       sql = new Sql(this.dataSource)
       sql.withTransaction {
@@ -147,11 +146,10 @@ class MariaDBManager implements IQueryService {
     } catch(Exception e) {
       String msg = "Retrieving locations for $identifier failed unexpectedly."
       log.error(msg, e)
-      response = HttpResponse.badRequest(msg)
     } finally {
       sql?.close()
     }
-    return response
+    return locations
   }
 
   /**

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -110,6 +110,7 @@ class MariaDBManager implements IQueryService {
     return response
   }
 
+  @Override
   Contact searchPersonByEmail(String email) {
     //    logger.info("Looking for user with email " + email + " in the DB");
     this.sql = new Sql(dataSource)
@@ -136,6 +137,13 @@ class MariaDBManager implements IQueryService {
       }
     }
     return res
+  }
+
+  @Override
+  Optional<List<Location>> getLocationsForPerson(String identifier) {
+    List<Location> locations = null
+    throw new RuntimeException("Method not implemented.")
+    return Optional.ofNullable(locations)
   }
 
   List<Location> listLocations() {

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -1,7 +1,7 @@
 package life.qbic.service;
 
 import javax.inject.Singleton
-import io.micronaut.http.HttpResponse
+
 import life.qbic.datamodel.services.*
 
 /**
@@ -15,7 +15,10 @@ interface ILocationService {
    * @param email email address
    * @return Contact object of the contact with the provided email address
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and might be removed in the future.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   Contact searchPersonByEmail(String email)
 
   /**
@@ -30,6 +33,18 @@ interface ILocationService {
    * @param email email address
    * @return list of Location objects
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and will be removed in the future. {@link #getLocationsForPerson} should be used instead.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   List<Location> getLocationsForEmail(String email)
+
+  /**
+   * List all locations attached to a person with the provided identifier.<br/>
+   * Currently one email address is used as identifier for a person in the system
+   * @param identifier the identifier for a person
+   * @return a list of locations if any could be found
+   * @since 1.1.0
+   */
+  Optional<List<Location>> getLocationsForPerson(String identifier)
 }

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -43,8 +43,8 @@ interface ILocationService {
    * List all locations attached to a person with the provided identifier.<br/>
    * Currently one email address is used as identifier for a person in the system
    * @param identifier the identifier for a person
-   * @return a list of locations if any could be found
+   * @return a list of locations found
    * @since 1.1.0
    */
-  Optional<List<Location>> getLocationsForPerson(String identifier)
+  List<Location> getLocationsForPerson(String identifier)
 }

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -43,8 +43,8 @@ interface ILocationService {
    * List all locations attached to a person with the provided identifier.<br/>
    * Currently one email address is used as identifier for a person in the system
    * @param identifier the identifier for a person
-   * @return a HttpResponse object containing a list of locations found, if the query was successful, failure status infos otherwise
+   * @return a list of locations found, if the query was successful, failure status infos otherwise
    * @since 1.1.0
    */
-  HttpResponse getLocationsForPerson(String identifier)
+  List<Location> getLocationsForPerson(String identifier)
 }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -39,7 +39,7 @@ class LocationServiceCenter implements ILocationService {
   }
 
   @Override
-  HttpResponse getLocationsForPerson(String identifier) {
+  List<Location> getLocationsForPerson(String identifier) {
     log.info "Listing all known locations for the person identified by $identifier"
     return database.getLocationsForPerson(identifier)
   }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -39,9 +39,9 @@ class LocationServiceCenter implements ILocationService {
   }
 
   @Override
-  Optional<List<Location>> getLocationsForPerson(String identifier) {
+  List<Location> getLocationsForPerson(String identifier) {
     throw new RuntimeException("Method not implemented.")
-    List<Location> locations = null
-    return Optional.ofNullable(locations)
+    List<Location> locations = new ArrayList<>()
+    return locations
   }
 }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -37,4 +37,11 @@ class LocationServiceCenter implements ILocationService {
     log.info "Listing all known locations for person with e-mail "+email
     return database.getLocationsForEmail(email);
   }
+
+  @Override
+  Optional<List<Location>> getLocationsForPerson(String identifier) {
+    throw new RuntimeException("Method not implemented.")
+    List<Location> locations = null
+    return Optional.ofNullable(locations)
+  }
 }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -40,8 +40,7 @@ class LocationServiceCenter implements ILocationService {
 
   @Override
   List<Location> getLocationsForPerson(String identifier) {
-    throw new RuntimeException("Method not implemented.")
-    List<Location> locations = new ArrayList<>()
-    return locations
+    log.info "Listing all known locations for the person identified by $identifier"
+    return database.getLocationsForPerson(identifier)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -102,7 +102,7 @@ class LocationsControllerIntegrationTest {
   @Test
   void testLocationsForUnknownUser() throws Exception {
     HttpRequest request = HttpRequest.GET("/locations/justreadtheinstructions").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String error = "noerror"
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -75,7 +75,8 @@ class LocationsControllerIntegrationTest {
   }
 
   @Test
-  void testLocationsMail() throws Exception {
+  void testLocationsUserID() throws Exception {
+    String user_id = "Morat"
     String email = "jernau@hassease.gv"
     String first = "Jernau"
     String last ="Gurgeh"
@@ -84,10 +85,10 @@ class LocationsControllerIntegrationTest {
     int zip = 0
     String country = "Chiark"
 
-    int personID = db.addPerson("Morat", first, last, email, "")
+    int personID = db.addPerson(user_id, first, last, email)
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/"+email).basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     assertEquals(arr.size(), 1)
@@ -97,9 +98,9 @@ class LocationsControllerIntegrationTest {
 
     db.removeLocationAndPerson(personID, locationID)
   }
-
+  
   @Test
-  void testMalformedLocationsMail() throws Exception {
+  void testLocationsForUnknownUser() throws Exception {
     HttpRequest request = HttpRequest.GET("/locations/justreadtheinstructions").basicAuth("servicewriter", "123456!")
     String error = ""
     try {
@@ -107,19 +108,34 @@ class LocationsControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       error = e.getMessage()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals("Bad Request", error)
+  }
+  
+  @Test
+  void testLocationsForUserWithoutLocations() throws Exception {
+    String user_id = "lonely"
+    String first = "A"
+    String last = "Hermit"
+    String email = "hermit@bugmenot.no"
+    int personID = db.addPerson(user_id, first, last, email)
+    HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
+    String body = client.toBlocking().retrieve(request)
+    JSONArray arr = new JSONArray(body)
+    assertEquals(arr.size(), 0)
+    
+    db.removePerson(personID)
   }
 
   @Test
   void testLocations() throws Exception {
     List<String> locNames = Arrays.asList("loc1","loc2","loc3")
-    int personID = db.addPerson("u1", "Paul", "Panther", "abc1@bla.de", "")
+    int personID = db.addPerson("u1", "Paul", "Panther", "abc1@bla.de")
     int locationID = db.addLocationForPerson("loc1", "street 1", "germany", 0, personID)
 
-    int personID2 = db.addPerson("u2", "Peter", "Parker", "abc2@bla.de", "")
+    int personID2 = db.addPerson("u2", "Peter", "Parker", "abc2@bla.de")
     int locationID2 = db.addLocationForPerson("loc2", "street 2", "united kingdom", 0, personID2)
 
-    int personID3 = db.addPerson("u3", "Markus", "Meier", "abc3@bla.de", "")
+    int personID3 = db.addPerson("u3", "Markus", "Meier", "abc3@bla.de")
     int locationID3 = db.addLocationForPerson("loc3", "street 3", "france", 0, personID3)
 
     HttpRequest request = HttpRequest.GET("/locations/").basicAuth("servicewriter", "123456!")
@@ -167,7 +183,7 @@ class LocationsControllerIntegrationTest {
     int zip = 0
     String country = "Chiark"
 
-    int personID = db.addPerson("Morat", first, last, email, "")
+    int personID = db.addPerson("Morat", first, last, email)
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
     HttpRequest request = HttpRequest.GET("/locations/contacts/"+email).basicAuth("servicewriter", "123456!")

--- a/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
@@ -1,0 +1,54 @@
+package life.qbic.controller
+
+import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.services.Address
+import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.services.Status
+import life.qbic.db.IQueryService
+import life.qbic.service.ILocationService
+import life.qbic.service.LocationServiceCenter
+import spock.lang.Specification
+
+/**
+ * This class tests some methods of the LocationsController
+ *
+ *
+ * @since: 1.1.0
+ */
+class LocationsControllerSpec extends Specification {
+
+
+    def "The locations endpoint retuns a correct number of locations"() {
+        given: "a user identifier"
+        String exampleUId = "test@qbic.de"
+
+        and: "a list of locations for these user identifiers"
+        Date date = new Date(new Date().getTime());
+        Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+        Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+        Location location1 = new Location(name: "Test Location 1", responsiblePerson: exampleUId, responsibleEmail: "example1", address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+        Location location2 = new Location(name: "Test Location 2", responsiblePerson: exampleUId, responsibleEmail: "example2", address: address2, status: Status.PROCESSING, arrivalDate: date, forwardDate: date)
+        Location location3 = new Location(name: "Test Location 3", responsiblePerson: exampleUId, responsibleEmail: "example2", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+        List<Location> locations = [location1, location2, location3]
+
+        and: "an ILocationService returning these locations"
+        ILocationService locationService = Mock(ILocationService, {
+            getLocationsForPerson(exampleUId) >> locations
+        })
+
+        and: "a LocationsController (under test) with this location service"
+        LocationsController locationsController = new LocationsController(locationService)
+
+        when: "the LocationsController is accessed through the /{user_id} endpoint"
+        HttpResponse response = locationsController.locations(exampleUId)
+
+        then: "the HttpResponse succeeds"
+        response.code() == 200
+        and: "there is a body returned"
+        response.body.isPresent()
+        and: "the response returns a list of locations"
+        response.body() instanceof List<Location>
+        and: "the list is as expected"
+        response.body() == locations
+    }
+}

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -81,11 +81,11 @@ class LocationsControllerTest {
     assertEquals(loc.size(),1)
   }
   
-  @Test
-  void testMalformedLocationsMail() throws Exception {
-    HttpResponse response = locations.locations("justreadtheinstructions")
-    assertEquals(response.getStatus().getCode(), 400)
-  }
+//  @Test
+//  void testMalformedLocationsMail() throws Exception {
+//    HttpResponse response = locations.locations("justreadtheinstructions")
+//    assertEquals(response.getStatus().getCode(), 400)
+//  }
   
   @Test
   void testLocations() throws Exception {

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -76,9 +76,9 @@ class LocationsControllerTest {
   @Test
   void testLocationsMail() throws Exception {
     HttpResponse response = locations.locations("right@right.de")
-    assertEquals(response.getStatus().getCode(), 200)
+    assertEquals(200, response.getStatus().getCode())
     List<Location> loc = response.body.orElse(null)
-    assertEquals(loc.size(),1)
+    assertEquals(1, loc.size())
   }
   
 //  @Test

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -55,7 +55,7 @@ class SamplesControllerIntegrationTest {
     db.loginWithCredentials(driver, url, user, pw);
 
     db.createTables()
-    db.addPerson("a", "b", "c", existingPersonMail, "0123")
+    db.addPerson("a", "b", "c", existingPersonMail)
     db.addLocation(existingLocation, "a", "b", 123)
   }
 
@@ -163,8 +163,8 @@ class SamplesControllerIntegrationTest {
     Location l1 = new Location(name: "Location 1", responsiblePerson: "Location 1 Person", responsibleEmail: email1, address: adr1, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
     Address adr2 = new Address(affiliation: "Location 2", country: "Germany", street: "Location 2 street", zipCode: 2)
     Location l2 = new Location(name: "Location 2", responsiblePerson: "Location 2 Person", responsibleEmail: email2, address: adr2, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
-    db.addPerson("u1","Location 1", "Person",email1,"123")
-    db.addPerson("u2","Location 2", "Person",email2,"456")
+    db.addPerson("u1","Location 1", "Person",email1)
+    db.addPerson("u2","Location 2", "Person",email2)
     db.addLocation(l1)
     db.addLocation(l2)
 
@@ -353,7 +353,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 1", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     int locID = db.addLocation(location.name, adr.street, adr.country, adr.zipCode)
-    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email, "123")
+    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email)
 
     HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
@@ -370,7 +370,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 1", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.METADATA_REGISTERED, arrivalDate: d);
     int locID = db.addLocation(location.name, adr.street, adr.country, adr.zipCode)
-    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email, "123")
+    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email)
     println location
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -110,7 +110,7 @@ class QueryMock implements IQueryService {
    * @return an optional containing two example locations for a Dummy user with the provided identifier
    * @InheritDoc
    */
-  @Override  Optional<List<Location>> getLocationsForPerson(String identifier) {
+  @Override  List<Location> getLocationsForPerson(String identifier) {
     Date date = new java.sql.Date(new Date().getTime());
     String responsiblePerson = "Dummy"
 
@@ -123,6 +123,6 @@ class QueryMock implements IQueryService {
     locations.add(location1)
     locations.add(location2)
 
-    return Optional.of(locations);
+    return locations;
   }
 }

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -110,7 +110,7 @@ class QueryMock implements IQueryService {
    * @return an optional containing two example locations for a Dummy user with the provided identifier
    * @InheritDoc
    */
-  @Override  List<Location> getLocationsForPerson(String identifier) {
+  @Override  HttpResponse<List<Location>> getLocationsForPerson(String identifier) {
     Date date = new java.sql.Date(new Date().getTime());
     String responsiblePerson = "Dummy"
 
@@ -121,6 +121,6 @@ class QueryMock implements IQueryService {
     List<Location> locations = new ArrayList<>()
     locations.add(location1)
 
-    return locations;
+    return HttpResponse.ok(locations);
   }
 }

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -110,7 +110,7 @@ class QueryMock implements IQueryService {
    * @return an optional containing two example locations for a Dummy user with the provided identifier
    * @InheritDoc
    */
-  @Override  HttpResponse<List<Location>> getLocationsForPerson(String identifier) {
+  @Override  List<Location> getLocationsForPerson(String identifier) {
     Date date = new java.sql.Date(new Date().getTime());
     String responsiblePerson = "Dummy"
 

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -103,4 +103,26 @@ class QueryMock implements IQueryService {
     }
     return res;
   }
+
+  /**
+   * This mocked method provides some example locations for the given identifier
+   *
+   * @return an optional containing two example locations for a Dummy user with the provided identifier
+   * @InheritDoc
+   */
+  @Override  Optional<List<Location>> getLocationsForPerson(String identifier) {
+    Date date = new java.sql.Date(new Date().getTime());
+    String responsiblePerson = "Dummy"
+
+    Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+    Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+    Location location1 = new Location(name: "Test Location 1", responsiblePerson: responsiblePerson, responsibleEmail: identifier, address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+    Location location2 = new Location(name: "Test Location 2", responsiblePerson: responsiblePerson, responsibleEmail: identifier, address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+
+    List<Location> locations = new ArrayList<>()
+    locations.add(location1)
+    locations.add(location2)
+
+    return Optional.of(locations);
+  }
 }

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -121,6 +121,6 @@ class QueryMock implements IQueryService {
     List<Location> locations = new ArrayList<>()
     locations.add(location1)
 
-    return HttpResponse.ok(locations);
+    return locations;
   }
 }

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -117,11 +117,9 @@ class QueryMock implements IQueryService {
     Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
     Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
     Location location1 = new Location(name: "Test Location 1", responsiblePerson: responsiblePerson, responsibleEmail: identifier, address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
-    Location location2 = new Location(name: "Test Location 2", responsiblePerson: responsiblePerson, responsibleEmail: identifier, address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
 
     List<Location> locations = new ArrayList<>()
     locations.add(location1)
-    locations.add(location2)
 
     return locations;
   }

--- a/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
+++ b/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
@@ -1,0 +1,47 @@
+package life.qbic.service
+
+import life.qbic.datamodel.services.Address
+import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.services.Status
+import life.qbic.db.IQueryService
+import spock.lang.Specification
+
+/**
+ * Specifies how the LocationServiceCenter should behave
+ *
+ * @since: 1.1.0
+ */
+class LocationServiceCenterSpec extends Specification {
+
+
+    def "GetLocationsForPerson returns locations from IQueryService"() {
+        given: "a user identifier"
+        String userId = "test@qbic.de"
+
+        and: "a list of locations for the id"
+        Date date = new Date(new Date().getTime());
+        Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+        Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+        Location location1 = new Location(name: "Test Location 1", responsiblePerson: userId, responsibleEmail: "example1", address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+        Location location2 = new Location(name: "Test Location 2", responsiblePerson: userId, responsibleEmail: "example2", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+        Location location3 = new Location(name: "Test Location 3", responsiblePerson: userId, responsibleEmail: "example3", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+
+        List<Location> locations = [location1, location2, location3]
+
+        and: "an IQueryService returning these locations"
+        IQueryService queryService = Mock(IQueryService, {
+            getLocationsForPerson(userId) >> locations
+        })
+
+        and: "a LocationServiceCenter with this queryService"
+        ILocationService locationService = new LocationServiceCenter(queryService)
+
+        when: "the LocationServiceCenter is asked to supply the locations for a given person"
+        List<Location> result = locationService.getLocationsForPerson(userId)
+
+        then: "the resulting list should contain all locations for the provided person"
+        result.size() == 3
+        and: "the content should be as expected"
+        result == locations
+    }
+}


### PR DESCRIPTION
This commit deprecates `getLocationsForEmail` and `searchPersonByEmail`.
The commit also introduces a method `getLocationsForPerson` to be used instead.

The change is necessary due to a change in user authentification and authorization in the userDb.
The users no longer are identified by their `email` field but rather have an additional `user-id` field.