### PR TITLE
Test for HttpStatus as well as for error messages

### DIFF
--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -210,12 +210,15 @@ class LocationsControllerIntegrationTest {
   @Test
   void testMalformedContact() throws Exception {
     HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -1,41 +1,20 @@
 package life.qbic.controller
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
-import io.micronaut.context.env.PropertySource
-import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.RxHttpClient
-import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
-import life.qbic.db.MariaDBManager
 import life.qbic.helpers.DBTester
-
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.ResultSet
-import java.sql.Statement
-import javax.inject.Inject
-
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.AfterClass
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 
@@ -92,10 +71,10 @@ class LocationsControllerIntegrationTest {
     HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
-    assertEquals(arr.size(), 1)
+    assertEquals(1, arr.size())
     JSONObject json = arr.getJSONObject(0)
 
-    assertEquals(json.get("name"),affName)
+    assertEquals(affName, json.get("name"))
 
     db.removeLocationAndPerson(personID, locationID)
   }
@@ -123,7 +102,7 @@ class LocationsControllerIntegrationTest {
     HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
-    assertEquals(arr.size(), 0)
+    assertEquals(0, arr.size())
     
     db.removePerson(personID)
   }
@@ -144,7 +123,7 @@ class LocationsControllerIntegrationTest {
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     println arr
-    assertEquals(arr.size(), 3)
+    assertEquals(3, arr.size())
     for(int i = 0; i<arr.size();i++) {
       JSONObject json = arr.getJSONObject(i)
       assert(locNames.contains(json.get("name")))
@@ -175,8 +154,8 @@ class LocationsControllerIntegrationTest {
       reason = responseException.getMessage()
       status = responseException.getStatus()
     }
-    assertEquals(status, HttpStatus.NOT_FOUND)
-    assertEquals(reason, expectedReason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
+    assertEquals(expectedReason, reason)
   }
 
   @Test
@@ -192,17 +171,17 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email)
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/contacts/"+email).basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/" + email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     assertNotNull(body)
-    assertEquals(json.get("full_name"),first+" "+last)
-    assertEquals(json.get("email"),email)
-    JSONObject address = json.get("address")
-    assertEquals(address.get("affiliation"),affName)
-    assertEquals(address.get("street"),street)
-    assertEquals(address.get("zip_code"),zip)
-    assertEquals(address.get("country"),country)
+    assertEquals(first + " " + last, json.get("full_name"))
+    assertEquals(email, json.get("email"))
+    JSONObject address = json.get("address") as JSONObject
+    assertEquals(affName, address.get("affiliation"))
+    assertEquals(street, address.get("street"))
+    assertEquals(zip, address.get("zip_code"))
+    assertEquals(country, address.get("country"))
 
     db.removeLocationAndPerson(personID, locationID)
   }
@@ -218,7 +197,7 @@ class LocationsControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -219,6 +219,6 @@ class LocationsControllerIntegrationTest {
       status = e.getStatus()
     }
     assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -82,8 +82,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
-    assertEquals(reason, "Bad Request")
+    assertEquals(HttpStatus.BAD_REQUEST, status)
+    assertEquals("Bad Request", reason)
   }
 
   @Test
@@ -95,7 +95,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.UNAUTHORIZED)
+    assertEquals(HttpStatus.UNAUTHORIZED, status)
   }
 
   @Test
@@ -127,9 +127,9 @@ class SamplesControllerIntegrationTest {
 
     Sample s = mapper.readValue(body, Sample.class);
     assertNotNull(s)
-    assertEquals(s.code,validCode1)
-    assertEquals(s.currentLocation,currentLocation)
-    assertEquals(s.pastLocations,pastLocations)
+    assertEquals(validCode1, s.code)
+    assertEquals(currentLocation, s.currentLocation)
+    assertEquals(pastLocations, s.pastLocations)
   }
 
   @Test void testReadSample() {
@@ -146,9 +146,9 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,"QTRAK005A9")
-      assertEquals(s.currentLocation,l1)
-      assertEquals(s.pastLocations,null)
+      assertEquals("QTRAK005A9", s.code)
+      assertEquals(l1, s.currentLocation)
+      assertEquals(null, s.pastLocations)
     }
   }
 
@@ -169,14 +169,14 @@ class SamplesControllerIntegrationTest {
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l1).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(response.status.getCode(), 200)
+      assertEquals(200, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
-      assertEquals(l1.address,testLocation.address)
-      assertEquals(l1.name,testLocation.name)
-      assertEquals(l1.status,testLocation.status)
-      assertEquals(l1.responsiblePerson,testLocation.responsiblePerson)
-      assertEquals(l1.responsibleEmail,testLocation.responsibleEmail)
+      assertEquals(l1.address, testLocation.address)
+      assertEquals(l1.name, testLocation.name)
+      assertEquals(l1.status, testLocation.status)
+      assertEquals(l1.responsiblePerson, testLocation.responsiblePerson)
+      assertEquals(l1.responsibleEmail, testLocation.responsibleEmail)
     }
 
     for(String code : codes) {
@@ -184,26 +184,26 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,code)
-      assertEquals(l1.address,s.currentLocation.address)
-      assertEquals(l1.name,s.currentLocation.name)
-      assertEquals(l1.status,s.currentLocation.status)
-      assertEquals(l1.responsiblePerson,s.currentLocation.responsiblePerson)
-      assertEquals(l1.responsibleEmail,s.currentLocation.responsibleEmail)
-      assertEquals(s.pastLocations,null)
+      assertEquals(code, s.code)
+      assertEquals(l1.address, s.currentLocation.address)
+      assertEquals(l1.name, s.currentLocation.name)
+      assertEquals(l1.status, s.currentLocation.status)
+      assertEquals(l1.responsiblePerson, s.currentLocation.responsiblePerson)
+      assertEquals(l1.responsibleEmail, s.currentLocation.responsibleEmail)
+      assertEquals(null, s.pastLocations)
     }
 
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l2).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(response.status.getCode(), 200)
+      assertEquals(200, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
-      assertEquals(l2.address,testLocation.address)
-      assertEquals(l2.name,testLocation.name)
-      assertEquals(l2.status,testLocation.status)
-      assertEquals(l2.responsiblePerson,testLocation.responsiblePerson)
-      assertEquals(l2.responsibleEmail,testLocation.responsibleEmail)
+      assertEquals(l2.address, testLocation.address)
+      assertEquals(l2.name, testLocation.name)
+      assertEquals(l2.status, testLocation.status)
+      assertEquals(l2.responsiblePerson, testLocation.responsiblePerson)
+      assertEquals(l2.responsibleEmail, testLocation.responsibleEmail)
     }
 
     for(String code : codes) {
@@ -211,13 +211,13 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,code)
+      assertEquals(code, s.code)
       assertEquals(l2.address,s.currentLocation.address)
       assertEquals(l2.name,s.currentLocation.name)
       assertEquals(l2.status,s.currentLocation.status)
       assertEquals(l2.responsiblePerson,s.currentLocation.responsiblePerson)
       assertEquals(l2.responsibleEmail,s.currentLocation.responsibleEmail)
-      assertEquals(s.pastLocations.size(),1)
+      assertEquals(1, s.pastLocations.size())
     }
   }
 
@@ -232,8 +232,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Not Found")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals("Not Found", reason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
 
@@ -249,8 +249,8 @@ class SamplesControllerIntegrationTest {
     reason = e.getMessage()
     status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -266,23 +266,23 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
-    assertEquals(body, "Sample status updated.")
+    assertEquals("Sample status updated.", body)
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     json = json.get("current_location")
-    assertEquals(json.get("sample_status"), Status.WAITING.toString());
+    assertEquals(Status.WAITING.toString(), json.get("sample_status"));
 
     request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","").basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
-    assertEquals(body, "Sample status updated.")
+    assertEquals("Sample status updated.", body)
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     json = new JSONObject(body);
     json = json.get("current_location")
-    assertEquals(json.get("sample_status"), Status.PROCESSED.toString());
+    assertEquals(Status.PROCESSED.toString(), json.get("sample_status"));
   }
 
   @Test
@@ -318,8 +318,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Not Found")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals("Not Found", reason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
   @Test
@@ -338,8 +338,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
 
@@ -368,9 +368,9 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
     Location testLocation = db.searchSample(validCode4).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -386,10 +386,10 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
 
     Location testLocation = db.searchSample(missingValidCode2).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -402,20 +402,20 @@ class SamplesControllerIntegrationTest {
     db.addSampleWithHistory(validCode5, location, currentPerson, new ArrayList<>(), new ArrayList<>())
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
 
     Location testLocation = db.searchSample(validCode5).currentLocation
 
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
 
     d = new java.sql.Date(new Date().getTime());
     location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
     request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode(), )
 
     testLocation = db.searchSample(validCode5).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -433,7 +433,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {          
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -451,7 +451,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {          
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -469,7 +469,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -487,6 +487,6 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -4,6 +4,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
 
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
@@ -73,25 +74,28 @@ class SamplesControllerIntegrationTest {
   @Test
   void testMalformedSample() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/wrong").basicAuth("servicewriter", "123456!")
-    String error = "";
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage();
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(reason, "Bad Request")
   }
 
   @Test
   void testAuthenticationRequired() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/" + validCode1)
-    def statusCode
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      statusCode = e.getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(401, statusCode)
+    assertEquals(status, HttpStatus.UNAUTHORIZED)
   }
 
   @Test
@@ -126,12 +130,6 @@ class SamplesControllerIntegrationTest {
     assertEquals(s.code,validCode1)
     assertEquals(s.currentLocation,currentLocation)
     assertEquals(s.pastLocations,pastLocations)
-    //    JSONObject json = new JSONObject(body);
-    //
-    //    assertNotNull(body)
-    //    assertEquals(json.get("code"),validCode1)
-    //    assertEquals(json.get("current_location"),currentLocation)
-    //    assertEquals(json.get("past_locations"),pastLocations)
   }
 
   @Test void testReadSample() {
@@ -226,26 +224,33 @@ class SamplesControllerIntegrationTest {
   @Test
   void testMissingSample() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/"+missingValidCode).basicAuth("servicewriter", "123456!")
-    String error = "";
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Not Found")
+    assertEquals(reason, "Not Found")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 
 
   @Test
   void testStatusMalformedSample() throws Exception {
     HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+          
+    reason = e.getMessage()
+    status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -305,13 +310,16 @@ class SamplesControllerIntegrationTest {
   void testStatusNoSample() throws Exception {
     String code = "QNONE001AC"
     HttpRequest request = HttpRequest.PUT("/samples/"+code+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Not Found")
+    assertEquals(reason, "Not Found")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 
   @Test
@@ -322,13 +330,16 @@ class SamplesControllerIntegrationTest {
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: "some@person.de", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
 
     HttpRequest request = HttpRequest.POST("/samples/"+malformedCode+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
 
@@ -415,13 +426,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 2", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-    } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+    } catch (HttpClientResponseException e) {          
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -432,13 +444,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 3", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-    } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+    } catch (HttpClientResponseException e) {          
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -449,13 +462,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 4", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -466,13 +480,13 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 5", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-      println response.getStatus()
     } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 }


### PR DESCRIPTION
This PR changes REST endpoint testing to test for returned HttpStatus as well. This is necessary because to verify return codes and the correct behaviour of the implemented service.