### PR TITLE
Update endpoint annotations

### DIFF
--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -50,28 +50,32 @@ class LocationsController {
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = Contact.class)))
-  @ApiResponse(responseCode = "400", description = "Invalid e-mail address")
+  @ApiResponse(responseCode = "400", description = "The provided e-mail address is invalid")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Contact for the provided e-mail address not found")
+  @ApiResponse(responseCode = "500", description = "Retrieval of contact information failed for an unknown reason")
   //@Deprecated(since=1.1.0, forRemoval=false) // works for Java11
   @Deprecated
-  HttpResponse<Contact> contacts(@PathVariable('email') String email){
-    if(!RegExValidator.isValidMail(email)) {
-      HttpResponse<Contact> res = HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid email address!")
+  HttpResponse<Contact> contacts(@PathVariable('email') String email) {
+    if (!RegExValidator.isValidMail(email)) {
+      HttpResponse<Contact> res = HttpResponse.status(HttpStatus.BAD_REQUEST, "${email} is not a valid email address!")
       return res
-    } else {
+    }
+    try {
       Contact contact = locService.searchPersonByEmail(email)
-      if(contact!=null) {
+      if (contact != null) {
         HttpResponse<Contact> res = HttpResponse.ok(contact)
         return res
-      }
-      else {
-        String reason = "Email address was not found in the system!"
+      } else {
+        String reason = "Email address ${email} was not found in the system!"
         HttpResponse<Contact> res = HttpResponse.status(HttpStatus.NOT_FOUND, reason);
         return res
       }
     }
-  }
+    catch (Exception e) {
+      return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e.message)
+    }
+    }
 
   @Get(uri = "/{user_id}", produces = MediaType.APPLICATION_JSON)
   @RolesAllowed(["READER"])
@@ -82,14 +86,20 @@ class LocationsController {
           content = @Content(
                   mediaType = "application/json",
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
-  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is not valid.")
+  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is invalid.")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
+  @ApiResponse(responseCode = "404", description = "location information for the provided user identifier not found")
+  @ApiResponse(responseCode = "500", description = "Retrieval of location information for the provided user failed for an unknown reason")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response
     List<Location> searchResult
     try {
       searchResult = locService.getLocationsForPerson(userId)
-      response = HttpResponse.ok(searchResult)
+      if (searchResult != null) {
+        response = HttpResponse.ok(searchResult)
+      } else {
+        response = HttpResponse.status(HttpStatus.NOT_FOUND, "Location information for user ${userId} was not found in the system!")
+      }
     } catch (IllegalArgumentException ignored) {
       response = HttpResponse.status(HttpStatus.BAD_REQUEST, ignored.getMessage())
     } catch (Exception ignored) {
@@ -107,9 +117,15 @@ class LocationsController {
                   mediaType = "application/json",
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
+  @ApiResponse(responseCode = "500", description = "Listing of available locations failed for an unknown reason")
   @RolesAllowed(["READER", "WRITER"])
   HttpResponse<List<Location>> listLocations() {
-    List<Location> res = locService.listLocations()
-    return HttpResponse.ok(res)
+    try {
+      List<Location> res = locService.listLocations()
+      return HttpResponse.ok(res)
+    }
+    catch (Exception e) {
+      HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e)
+    }
   }
 }

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -52,7 +52,7 @@ class LocationsController {
                         schema = @Schema(implementation = Contact.class)))
   @ApiResponse(responseCode = "400", description = "Invalid e-mail address")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
-  @ApiResponse(responseCode = "404", description = "Contact not found")
+  @ApiResponse(responseCode = "404", description = "Contact for the provided e-mail address not found")
   //@Deprecated(since=1.1.0, forRemoval=false) // works for Java11
   @Deprecated
   HttpResponse<Contact> contacts(@PathVariable('email') String email){
@@ -74,16 +74,16 @@ class LocationsController {
   }
 
   @Get(uri = "/{user_id}", produces = MediaType.APPLICATION_JSON)
-  @Operation(summary = "Provides the locations information linked to a username",
-          description = "Provides detailed locations information that is linked to a username",
-          tags = "Contact")
-  @ApiResponse(responseCode = "200", description = "Current locations associated with the username",
+  @RolesAllowed(["READER"])
+  @Operation(summary = "Provides the locations information linked to a user identifier",
+          description = "Provides detailed locations information that is linked to a user",
+          tags = "Location")
+  @ApiResponse(responseCode = "200", description = "Location information associated with the user identifier is provided",
           content = @Content(
                   mediaType = "application/json",
-                  schema = @Schema(implementation = Location.class)))
-  @ApiResponse(responseCode = "400", description = "Bad Request")
-  @ApiResponse(responseCode = "500", description = "Unexpected error during execution")
-  @RolesAllowed(["READER"])
+                  array = @ArraySchema(schema = @Schema(implementation = Location.class))))
+  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is not valid.")
+  @ApiResponse(responseCode = "401", description = "Unauthorized access")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response
     List<Location> searchResult
@@ -96,7 +96,6 @@ class LocationsController {
       response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, ignored.getMessage())
     }
     return response
-    
   }
 
   @Get(uri = "/", produces = MediaType.APPLICATION_JSON)

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -88,7 +88,7 @@ class LocationsController {
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
   @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is invalid.")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
-  @ApiResponse(responseCode = "404", description = "location information for the provided user identifier not found")
+  @ApiResponse(responseCode = "404", description = "Location information for the provided user identifier not found")
   @ApiResponse(responseCode = "500", description = "Retrieval of location information for the provided user failed for an unknown reason")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -68,7 +68,7 @@ class SamplesController {
   @Operation(summary = "Sets a sample's current location",
           description = "Sets a sample current location with the given identifier.",
           tags = "Sample Location")
-  @ApiResponse(responseCode = "200", description = "Current location for sample set successfully")
+  @ApiResponse(responseCode = "201", description = "Current location for sample set successfully")
   @ApiResponse(responseCode = "400", description = "Sample identifier format does not match")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Sample for the provided identifier not found")
@@ -130,7 +130,7 @@ class SamplesController {
   @Operation(summary = "Sets a sample's current location status",
           description = "Sets a sample current location status with the given identifier.",
           tags = "Sample Status")
-  @ApiResponse(responseCode = "200", description = "Current location for sample set successfully")
+  @ApiResponse(responseCode = "201", description = "Current location for sample set successfully")
   @ApiResponse(responseCode = "400", description = "Sample identifier format does not match")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Sample for the provided identifier not found")

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -102,7 +102,7 @@ class SamplesControllerTest {
   }
 
   @Test
-  void MissingSampleNewLocation() throws Exception {
+  void testMissingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
@@ -110,7 +110,7 @@ class SamplesControllerTest {
     assertEquals(404, response.status.getCode())
   }
   @Test
-  void ExistingSampleNewLocation() throws Exception {
+  void testExistingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -102,11 +102,19 @@ class SamplesControllerTest {
   }
 
   @Test
-  void testSampleNewLocation() throws Exception {
+  void MissingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation(validMissingCode, location)
+    assertEquals(404, response.status.getCode())
+  }
+  @Test
+  void ExistingSampleNewLocation() throws Exception {
+    Date d = new java.sql.Date(new Date().getTime());
+    Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
+    Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
+    HttpResponse response = samples.newLocation(existingCode, location)
     assertEquals(201, response.status.getCode())
   }
 


### PR DESCRIPTION
**Purpose of change**
This PR updates the REST API annotations for the service controller as was requested in #23 

**Change**
This PR adds the missing APIResponse Codes since the response code generation was moved to the controllers in #24. 
Additionally it accounts for the possibility of thrown exceptions by adding try catch blocks with the corresponding APIResponse to each method. 
Lastly, the response string of the individual HTTPResponses return a more specified message.