### PR TITLE
Include Data-model-lib 1.13.0-SNAPSHOT and fix test annotation 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>1.6.0</version>
+			<version>1.13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micronaut.configuration</groupId>

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -14,8 +14,9 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.auth.Authentication
 import life.qbic.service.ILocationService
 

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -12,9 +12,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.samples.Status
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+
 import life.qbic.micronaututils.auth.Authentication
 import life.qbic.service.ISampleService
 

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -2,7 +2,8 @@ package life.qbic.db;
 
 import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Interface for database queries

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -6,7 +6,9 @@ import groovy.sql.Sql
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.QBiCDataSource
 
 import javax.inject.Inject

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -2,7 +2,9 @@ package life.qbic.service;
 
 import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Service interface to search location and contact information

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -3,7 +3,9 @@ package life.qbic.service
 import life.qbic.db.NotFoundException;
 
 import javax.inject.Singleton
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Service interface to search and update sample information

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -7,7 +7,9 @@ import javax.inject.Singleton
 
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Log4j2

--- a/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
@@ -5,7 +5,9 @@ import javax.inject.Singleton
 
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Singleton

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -144,10 +144,11 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testNonExistingContact() throws Exception {
-    String expectedReason = "Email address was not found in the system!"
+    String emailAddress = "ian.banks@limitingfactor.com"
+    String expectedReason = "Email address ${emailAddress} was not found in the system!"
     String reason
     HttpStatus status
-    HttpRequest request = HttpRequest.GET("/locations/contacts/ian.banks@limitingfactor.com").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/${emailAddress}").basicAuth("servicewriter", "123456!")
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException responseException) {
@@ -188,7 +189,8 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
+    String invalidContact = "justreadtheinstructions"
+    HttpRequest request = HttpRequest.GET("/locations/contacts/${invalidContact}").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -197,7 +199,7 @@ class LocationsControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not a valid email address!", reason)
+    assertEquals("${invalidContact} is not a valid email address!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
@@ -2,9 +2,9 @@ package life.qbic.controller
 
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 import life.qbic.service.ILocationService
 import life.qbic.service.LocationServiceCenter

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -16,9 +16,9 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import life.qbic.controller.LocationsController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.helpers.QueryMock
 import life.qbic.service.LocationServiceCenter
 
@@ -58,9 +58,9 @@ class LocationsControllerTest {
     assertEquals(response.getStatus().getCode(),200)
     Contact c = response.body.orElse(null)
 
-    assertEquals(c.fullName,first+" "+last)
+    assertEquals(c.fullName, first+" "+last)
     assertEquals(c.email,email)
-    Address address = c.address
+    Address address = c.getAddress()
     assertEquals(address.affiliation,affName)
     assertEquals(address.street,street)
     assertEquals(address.zipCode,zip)

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -9,7 +9,9 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.helpers.DBTester
 import org.json.JSONObject
 import org.junit.AfterClass
@@ -71,7 +73,8 @@ class SamplesControllerIntegrationTest {
 
   @Test
   void testMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.GET("/samples/wrong").basicAuth("servicewriter", "123456!")
+    String malformedSample = "wrong"
+    HttpRequest request = HttpRequest.GET("/samples/${malformedSample}").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -81,7 +84,7 @@ class SamplesControllerIntegrationTest {
       status = e.getStatus()
     }
     assertEquals(HttpStatus.BAD_REQUEST, status)
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedSample} is not a valid sample identifier!".toString(), reason)
   }
 
   @Test
@@ -230,14 +233,15 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Sample was not found in the system!", reason)
+    assertEquals("Sample with ID ${missingValidCode} was not found in the system!".toString(), reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
 
   @Test
   void testStatusMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
+    String malformedSample = "wrong"
+    HttpRequest request = HttpRequest.PUT("/samples/${malformedSample}/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -247,7 +251,7 @@ class SamplesControllerIntegrationTest {
     reason = e.getMessage()
     status = e.getStatus()
     }
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedSample} is not a valid sample identifier!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
@@ -265,7 +269,7 @@ class SamplesControllerIntegrationTest {
 
     HttpResponse response  = client.toBlocking().exchange(request)
     assertEquals(201, response.status.getCode())
-    assertEquals("Sample status updated.", response.reason())
+    assertEquals("Sample status updated to ${response.getStatus()}.".toString(), response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
@@ -317,7 +321,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Sample was not found in the system!", reason)
+    assertEquals("Sample with ID ${code} was not found in the system!".toString(), reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
@@ -337,7 +341,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedCode} is not a valid sample identifier!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -16,10 +16,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import life.qbic.controller.SamplesController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
 import life.qbic.db.IQueryService
 import life.qbic.helpers.QueryMock
 import life.qbic.service.ISampleService
@@ -30,6 +26,9 @@ import org.junit.BeforeClass
 import org.junit.Test
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 class SamplesControllerTest {
 

--- a/src/test/groovy/life/qbic/helpers/DBTester.groovy
+++ b/src/test/groovy/life/qbic/helpers/DBTester.groovy
@@ -16,7 +16,9 @@ import javax.inject.Singleton
 
 import groovy.sql.ResultSetMetaDataWrapper
 import groovy.util.logging.Log4j2
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.QBiCDataSource
 
 @Log4j2

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -19,11 +19,9 @@ import java.util.regex.Matcher
 import javax.inject.Inject
 import javax.inject.Singleton
 
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Requires(missingBeans=javax.sql.DataSource)

--- a/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
+++ b/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
@@ -1,8 +1,8 @@
 package life.qbic.service
 
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 import spock.lang.Specification
 


### PR DESCRIPTION
**Description of changes**
This PR achieves 2 things: 
1. Include the newest version of `data-model-lib`(from 1.6 to 1.13.0-SNAPSHOT)
2. Update the tests in term of output strings to account for the changed API Messages in #22 

To 1.) Classes such as `Location`, `Address`, `Contact` and `Status` were moved in `data-model-lib` from the `life.qbic.datamodel.services` directory  into the `life.qbic.datamodel.people` and the `life.qbic.datamodel.samples` directory. This means that the import statements had to be updated for most of the classes in the sample-tracking service.

**Additional context**
This PR is dependent on the resolvement of [#152](https://github.com/qbicsoftware/data-model-lib/pull/152). The newest data-model-lib version introduces groovy 3.0.7 which causes he tests to fail because of a `java.lang.AbstractMethodError`. 