### PR TITLE
Hotfix/1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Release 1.0.6 (2021-02-22)
+- Increase `data-model-lib:1.6.0` -> `2.0.0`
+  - The following imports were changed `life.qbic.datamodel.`
+    * `services.Sample` -> `samples.Sample`
+    * `services.Location` -> `samples.Location`
+    * `services.Status` -> `samples.Status`
+    * `services.Address` -> `people.Address`
+    * `services.Contact` -> `people.Contact`
+    * `services.Person` -> `people.Person`
+
 ## Release 1.0.5 (2021-01-28)
 
 - Configures JDBC Driver to use a connection pool

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<!--groupId>life.qbic</groupId -->
 	<artifactId>sampletracking</artifactId>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>service-parent-pom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>1.6.0</version>
+			<version>2.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micronaut.configuration</groupId>

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -1,11 +1,10 @@
 package life.qbic.controller
 
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.PathVariable
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
@@ -14,14 +13,13 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import life.qbic.datamodel.services.Sample
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
 import life.qbic.micronaututils.auth.Authentication
+import life.qbic.service.ILocationService
 
 import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
-import life.qbic.service.ILocationService
 
 @Requires(beans = Authentication.class)
 @Secured(SecurityRule.IS_AUTHENTICATED)

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -1,26 +1,24 @@
 package life.qbic.controller
 
-import io.micronaut.context.annotation.Parameter
+
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.PathVariable
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.*
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 import life.qbic.micronaututils.auth.Authentication
+import life.qbic.service.ISampleService
 
 import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
-import life.qbic.datamodel.services.*
-import life.qbic.service.ISampleService
 
 @Requires(beans = Authentication.class)
 @Secured(SecurityRule.IS_AUTHENTICATED)

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -1,8 +1,12 @@
-package life.qbic.db;
+package life.qbic.db
+
+import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 
 import javax.inject.Singleton
-import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
 
 @Singleton
 interface IQueryService {

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -1,34 +1,26 @@
 package life.qbic.db
 
-import io.micronaut.context.annotation.Requires
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 import groovy.util.logging.Log4j2
-import io.micronaut.context.annotation.Property
-import io.micronaut.context.event.BeanCreatedEvent
-import io.micronaut.context.event.BeanCreatedEventListener
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.HttpStatus
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Produces
-import io.micronaut.http.annotation.Put
-import life.qbic.datamodel.services.*
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.people.Person
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 import life.qbic.micronaututils.QBiCDataSource
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import javax.sql.DataSource
 import java.sql.Connection
-import java.sql.Date
-import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Timestamp
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.time.OffsetDateTime
-import java.util.regex.Matcher
-import javax.inject.Inject
-import javax.inject.Singleton
-import javax.sql.DataSource
-import javax.validation.metadata.ReturnValueDescriptor
 
 @Log4j2
 @Singleton

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -1,8 +1,9 @@
-package life.qbic.service;
+package life.qbic.service
+
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
 
 import javax.inject.Singleton
-import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
 
 @Singleton
 interface ILocationService {

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -1,8 +1,11 @@
-package life.qbic.service;
+package life.qbic.service
+
+import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 
 import javax.inject.Singleton
-import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
 
 @Singleton
 interface ISampleService {

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -1,14 +1,12 @@
-package life.qbic.service;
+package life.qbic.service
 
-import java.util.List
+import groovy.util.logging.Log4j2
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
+import life.qbic.db.IQueryService
 
 import javax.inject.Inject
 import javax.inject.Singleton
-
-import groovy.util.logging.Log4j2
-import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
-import life.qbic.db.IQueryService
 
 @Log4j2
 @Singleton

--- a/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
@@ -1,12 +1,14 @@
-package life.qbic.service;
-
-import javax.inject.Inject
-import javax.inject.Singleton
+package life.qbic.service
 
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 import life.qbic.db.IQueryService
+
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Singleton
 @Log4j2

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -1,40 +1,19 @@
 package life.qbic.controller
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
-import io.micronaut.context.env.PropertySource
-import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.RxHttpClient
-import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
-import life.qbic.db.MariaDBManager
 import life.qbic.helpers.DBTester
-
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.ResultSet
-import java.sql.Statement
-import javax.inject.Inject
-
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.AfterClass
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -1,33 +1,16 @@
 package life.qbic.controller
 
-import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.env.Environment
-import io.micronaut.context.env.PropertySource
-import io.micronaut.core.util.CollectionUtils
-import io.micronaut.http.HttpRequest
+
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
-import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.exceptions.HttpClientResponseException
-import io.micronaut.runtime.server.EmbeddedServer
-import life.qbic.controller.LocationsController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
 import life.qbic.helpers.QueryMock
 import life.qbic.service.LocationServiceCenter
-
-import org.junit.AfterClass
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
 
 class LocationsControllerTest {
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -1,24 +1,26 @@
 package life.qbic.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
-
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
-import life.qbic.datamodel.services.*
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.people.Person
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 import life.qbic.helpers.DBTester
-
 import org.json.JSONObject
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
-
-import com.fasterxml.jackson.databind.ObjectMapper
 
 class SamplesControllerIntegrationTest {
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -1,33 +1,17 @@
 package life.qbic.controller
 
-import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.env.Environment
-import io.micronaut.context.env.PropertySource
-import io.micronaut.core.util.CollectionUtils
-import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
-import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.exceptions.HttpClientResponseException
-import io.micronaut.runtime.server.EmbeddedServer
-import life.qbic.controller.SamplesController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
 import life.qbic.db.IQueryService
 import life.qbic.helpers.QueryMock
 import life.qbic.service.ISampleService
 import life.qbic.service.SampleServiceCenter
-import org.junit.AfterClass
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 

--- a/src/test/groovy/life/qbic/helpers/DBTester.groovy
+++ b/src/test/groovy/life/qbic/helpers/DBTester.groovy
@@ -1,23 +1,16 @@
 package life.qbic.helpers
 
-import java.sql.DriverManager
-import java.sql.Connection
-import java.sql.PreparedStatement
-import java.sql.ResultSet
-import java.sql.ResultSetMetaData
-import java.sql.SQLException
-import java.sql.Timestamp
-import java.sql.Statement
+import groovy.util.logging.Log4j2
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.people.Person
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.samples.Status
+
+import java.sql.*
 import java.text.DateFormat
 import java.text.SimpleDateFormat
-
-import javax.inject.Inject
-import javax.inject.Singleton
-
-import groovy.sql.ResultSetMetaDataWrapper
-import groovy.util.logging.Log4j2
-import life.qbic.datamodel.services.*
-import life.qbic.micronaututils.QBiCDataSource
+import java.util.Date
 
 @Log4j2
 class DBTester {

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -1,29 +1,13 @@
 package life.qbic.helpers
 
-import io.micronaut.context.annotation.Parameter
+
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.HttpStatus
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Produces
-import io.micronaut.http.annotation.Put
-
-import java.sql.Connection
-import java.sql.PreparedStatement
-import java.sql.ResultSet
-import java.sql.SQLException
-import java.util.List
-import java.util.regex.Matcher
-import javax.inject.Inject
-import javax.inject.Singleton
-
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.Contact
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+import life.qbic.datamodel.people.Address
+import life.qbic.datamodel.samples.Status
 import life.qbic.db.IQueryService
 
 @Requires(missingBeans=javax.sql.DataSource)


### PR DESCRIPTION
## Release 1.0.6 (2021-02-22)
- Increase `data-model-lib:1.6.0` -> `2.0.0`
  - The following imports were changed `life.qbic.datamodel.`
    * `services.Sample` -> `samples.Sample`
    * `services.Location` -> `samples.Location`
    * `services.Status` -> `samples.Status`
    * `services.Address` -> `people.Address`
    * `services.Contact` -> `people.Contact`
    * `services.Person` -> `people.Person`