### PR TITLE
Bump data-model-lib:2.0.0 to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Release 1.0.7 (2021-03-18)
+- Increase `data-model-lib:2.0.0` -> `2.4.0`
+
 ## Release 1.0.6 (2021-02-22)
 - Increase `data-model-lib:1.6.0` -> `2.0.0`
   - The following imports were changed `life.qbic.datamodel.`

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>2.0.0</version>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micronaut.configuration</groupId>


### PR DESCRIPTION
## Release 1.0.7 (2021-03-18)
- Increase `data-model-lib:2.0.0` -> `2.4.0`