### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Add missing JavaDoc (Issue #15)
 - the `/{email}` endpoint now searches by the newly introduced `user_id` instead.
     This is no change in the behaviour as of now since they are identical as of now.
+- HttpResponses now contain the error messages in the status reason 
+    instead of the response body  
+
 ## Release 1.0.4
 
 - Append new location to history even if old location is the same as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+- Add missing JavaDoc (Issue #15)
+- the `/{email}` endpoint now searches by the newly introduced `user_id` instead.
+    This is no change in the behaviour as of now since they are identical as of now.
 ## Release 1.0.4
 
 - Append new location to history even if old location is the same as

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<!--groupId>life.qbic</groupId -->
 	<artifactId>sampletracking</artifactId>
-	<version>1.0.7</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>service-parent-pom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>1.6.0</version>
+			<version>1.13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micronaut.configuration</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<!--groupId>life.qbic</groupId -->
 	<artifactId>sampletracking</artifactId>
-	<version>1.0.4</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>service-parent-pom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<!--groupId>life.qbic</groupId -->
 	<artifactId>sampletracking</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.0</version>
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>service-parent-pom</artifactId>

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -14,8 +14,9 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.auth.Authentication
 import life.qbic.service.ILocationService
 

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -50,28 +50,32 @@ class LocationsController {
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = Contact.class)))
-  @ApiResponse(responseCode = "400", description = "Invalid e-mail address")
+  @ApiResponse(responseCode = "400", description = "The provided e-mail address is invalid")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Contact for the provided e-mail address not found")
+  @ApiResponse(responseCode = "500", description = "Retrieval of contact information failed for an unknown reason")
   //@Deprecated(since=1.1.0, forRemoval=false) // works for Java11
   @Deprecated
-  HttpResponse<Contact> contacts(@PathVariable('email') String email){
-    if(!RegExValidator.isValidMail(email)) {
-      HttpResponse<Contact> res = HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid email address!")
+  HttpResponse<Contact> contacts(@PathVariable('email') String email) {
+    if (!RegExValidator.isValidMail(email)) {
+      HttpResponse<Contact> res = HttpResponse.status(HttpStatus.BAD_REQUEST, "${email} is not a valid email address!")
       return res
-    } else {
+    }
+    try {
       Contact contact = locService.searchPersonByEmail(email)
-      if(contact!=null) {
+      if (contact != null) {
         HttpResponse<Contact> res = HttpResponse.ok(contact)
         return res
-      }
-      else {
-        String reason = "Email address was not found in the system!"
+      } else {
+        String reason = "Email address ${email} was not found in the system!"
         HttpResponse<Contact> res = HttpResponse.status(HttpStatus.NOT_FOUND, reason);
         return res
       }
     }
-  }
+    catch (Exception e) {
+      return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e.message)
+    }
+    }
 
   @Get(uri = "/{user_id}", produces = MediaType.APPLICATION_JSON)
   @RolesAllowed(["READER"])
@@ -82,14 +86,20 @@ class LocationsController {
           content = @Content(
                   mediaType = "application/json",
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
-  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is not valid.")
+  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is invalid.")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
+  @ApiResponse(responseCode = "404", description = "location information for the provided user identifier not found")
+  @ApiResponse(responseCode = "500", description = "Retrieval of location information for the provided user failed for an unknown reason")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response
     List<Location> searchResult
     try {
       searchResult = locService.getLocationsForPerson(userId)
-      response = HttpResponse.ok(searchResult)
+      if (searchResult != null) {
+        response = HttpResponse.ok(searchResult)
+      } else {
+        response = HttpResponse.status(HttpStatus.NOT_FOUND, "Location information for user ${userId} was not found in the system!")
+      }
     } catch (IllegalArgumentException ignored) {
       response = HttpResponse.status(HttpStatus.BAD_REQUEST, ignored.getMessage())
     } catch (Exception ignored) {
@@ -107,9 +117,15 @@ class LocationsController {
                   mediaType = "application/json",
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
+  @ApiResponse(responseCode = "500", description = "Listing of available locations failed for an unknown reason")
   @RolesAllowed(["READER", "WRITER"])
   HttpResponse<List<Location>> listLocations() {
-    List<Location> res = locService.listLocations()
-    return HttpResponse.ok(res)
+    try {
+      List<Location> res = locService.listLocations()
+      return HttpResponse.ok(res)
+    }
+    catch (Exception e) {
+      HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e)
+    }
   }
 }

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -52,7 +52,7 @@ class LocationsController {
                         schema = @Schema(implementation = Contact.class)))
   @ApiResponse(responseCode = "400", description = "Invalid e-mail address")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
-  @ApiResponse(responseCode = "404", description = "Contact not found")
+  @ApiResponse(responseCode = "404", description = "Contact for the provided e-mail address not found")
   //@Deprecated(since=1.1.0, forRemoval=false) // works for Java11
   @Deprecated
   HttpResponse<Contact> contacts(@PathVariable('email') String email){
@@ -74,16 +74,16 @@ class LocationsController {
   }
 
   @Get(uri = "/{user_id}", produces = MediaType.APPLICATION_JSON)
-  @Operation(summary = "Provides the locations information linked to a username",
-          description = "Provides detailed locations information that is linked to a username",
-          tags = "Contact")
-  @ApiResponse(responseCode = "200", description = "Current locations associated with the username",
+  @RolesAllowed(["READER"])
+  @Operation(summary = "Provides the locations information linked to a user identifier",
+          description = "Provides detailed locations information that is linked to a user",
+          tags = "Location")
+  @ApiResponse(responseCode = "200", description = "Location information associated with the user identifier is provided",
           content = @Content(
                   mediaType = "application/json",
-                  schema = @Schema(implementation = Location.class)))
-  @ApiResponse(responseCode = "400", description = "Bad Request")
-  @ApiResponse(responseCode = "500", description = "Unexpected error during execution")
-  @RolesAllowed(["READER"])
+                  array = @ArraySchema(schema = @Schema(implementation = Location.class))))
+  @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is not valid.")
+  @ApiResponse(responseCode = "401", description = "Unauthorized access")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response
     List<Location> searchResult
@@ -96,7 +96,6 @@ class LocationsController {
       response = HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, ignored.getMessage())
     }
     return response
-    
   }
 
   @Get(uri = "/", produces = MediaType.APPLICATION_JSON)

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -88,7 +88,7 @@ class LocationsController {
                   array = @ArraySchema(schema = @Schema(implementation = Location.class))))
   @ApiResponse(responseCode = "400", description = "Bad Request. The provided user identification is invalid.")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
-  @ApiResponse(responseCode = "404", description = "location information for the provided user identifier not found")
+  @ApiResponse(responseCode = "404", description = "Location information for the provided user identifier not found")
   @ApiResponse(responseCode = "500", description = "Retrieval of location information for the provided user failed for an unknown reason")
   HttpResponse<List<Location>> locations(@PathVariable('user_id') String userId) {
     HttpResponse<List<Location>> response

--- a/src/main/groovy/life/qbic/controller/LocationsController.groovy
+++ b/src/main/groovy/life/qbic/controller/LocationsController.groovy
@@ -57,7 +57,7 @@ class LocationsController {
   @Deprecated
   HttpResponse<Contact> contacts(@PathVariable('email') String email){
     if(!RegExValidator.isValidMail(email)) {
-      HttpResponse<Contact> res = HttpResponse.badRequest("Not a valid email address!")
+      HttpResponse<Contact> res = HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid email address!")
       return res
     } else {
       Contact contact = locService.searchPersonByEmail(email)

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -68,7 +68,7 @@ class SamplesController {
   @Operation(summary = "Sets a sample's current location",
           description = "Sets a sample current location with the given identifier.",
           tags = "Sample Location")
-  @ApiResponse(responseCode = "200", description = "Current location for sample set successfully")
+  @ApiResponse(responseCode = "201", description = "Current location for sample set successfully")
   @ApiResponse(responseCode = "400", description = "Sample identifier format does not match")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Sample for the provided identifier not found")
@@ -130,7 +130,7 @@ class SamplesController {
   @Operation(summary = "Sets a sample's current location status",
           description = "Sets a sample current location status with the given identifier.",
           tags = "Sample Status")
-  @ApiResponse(responseCode = "200", description = "Current location for sample set successfully")
+  @ApiResponse(responseCode = "201", description = "Current location for sample set successfully")
   @ApiResponse(responseCode = "400", description = "Sample identifier format does not match")
   @ApiResponse(responseCode = "401", description = "Unauthorized access")
   @ApiResponse(responseCode = "404", description = "Sample for the provided identifier not found")

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -12,9 +12,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.samples.Status
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
+
 import life.qbic.micronaututils.auth.Authentication
 import life.qbic.service.ISampleService
 

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -81,6 +81,8 @@ class SamplesController {
     try{
         sampleService.addNewLocation(sampleId, location)
         return HttpResponse.ok(location)
+    } catch (IllegalArgumentException illegalArgumentException) {
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, illegalArgumentException.message)
     } catch(Exception e) {
         return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e.message)
     }
@@ -107,13 +109,10 @@ class SamplesController {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "${sampleId} is not a valid sample identifier!")
     }
     try {
-//      if (null != sampleService.searchSample(sampleId)) {
-        sampleService.updateLocation(sampleId, location)
-//        return HttpResponse.ok(location)
-//      }
-//      else {
-//        return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample with ID ${sampleId} was not found in the system!")
-//      }
+      sampleService.updateLocation(sampleId, location)
+      return HttpResponse.ok(location)
+    } catch (IllegalArgumentException illegalArgumentException) {
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, illegalArgumentException.message)
     } catch(Exception e){
       return HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, e.message)
     }

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -1,26 +1,25 @@
 package life.qbic.controller
 
-import io.micronaut.context.annotation.Parameter
+
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.PathVariable
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.*
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.services.Sample
+import life.qbic.datamodel.services.Status
 import life.qbic.micronaututils.auth.Authentication
+import life.qbic.service.ISampleService
 
 import javax.annotation.security.RolesAllowed
 import javax.inject.Inject
-import life.qbic.datamodel.services.*
-import life.qbic.service.ISampleService
 
 @Requires(beans = Authentication.class)
 @Secured(SecurityRule.IS_AUTHENTICATED)
@@ -48,13 +47,13 @@ class SamplesController {
   @RolesAllowed([ "READER", "WRITER"])
   HttpResponse<Sample> sample(@PathVariable('sampleId') String code) {
     if(!RegExValidator.isValidSampleCode(code)) {
-      return HttpResponse.badRequest("Not a valid sample code!");
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
       Sample s = sampleService.searchSample(code);
       if(s!=null) {
         return HttpResponse.ok(s);
       } else {
-        return HttpResponse.notFound("Sample was not found in the system!");
+        return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
       }
     }
   }
@@ -70,7 +69,7 @@ class SamplesController {
   @RolesAllowed("WRITER")
   HttpResponse<Location> newLocation(@PathVariable('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
-      return HttpResponse.badRequest("Not a valid sample code!");
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
       return sampleService.addNewLocation(sampleId, location)
     }
@@ -93,7 +92,7 @@ class SamplesController {
   @RolesAllowed("WRITER")
   HttpResponse<Location> updateLocation(@PathVariable('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
-      return HttpResponse.badRequest("Not a valid sample code!");
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
       return sampleService.updateLocation(sampleId, location)
     }
@@ -110,14 +109,17 @@ class SamplesController {
   @RolesAllowed("WRITER")
   HttpResponse sampleStatus(@PathVariable('sampleId') String sampleId, @PathVariable('status') Status status) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
-      return HttpResponse.badRequest("Not a valid sample code!");
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     }
     boolean found = sampleService.searchSample(sampleId)!=null;
     if(found) {
       sampleService.updateSampleStatus(sampleId, status);
-      return HttpResponse.created("Sample status updated.");
+      String msg = "Sample status updated."
+      HttpResponse response = HttpResponse.status(HttpStatus.CREATED, msg)
+      response.body(msg)
+      return response
     } else {
-      return HttpResponse.notFound("Sample was not found in the system!");
+      return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
     }
   }
 }

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -75,8 +75,9 @@ class SamplesController {
     try{
       sampleService.addNewLocation(sampleId, location)
       return HttpResponse.ok(location)
-    } catch(Exception e) {
-        return HttpResponse.status(HttpStatus.BAD_REQUEST, "Could not add Sample to Location in the system!")
+    }
+    catch(Exception e) {
+        return HttpResponse.status(HttpStatus.BAD_REQUEST, e.message) //todo find status dynamically??
     }
   }
 
@@ -104,7 +105,7 @@ class SamplesController {
       return HttpResponse.ok(location)
     }
     catch(Exception e){
-      return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample and Location were not found in the system!")
+      return HttpResponse.status(HttpStatus.BAD_REQUEST, e.message) //todo find response dynamically
     }
   }
 

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -74,7 +74,7 @@ class SamplesController {
     }
     try{
       sampleService.addNewLocation(sampleId, location)
-      return HttpResponse.ok(location)
+      return HttpResponse.created(location)
     }
     catch(Exception e) {
         return HttpResponse.status(HttpStatus.BAD_REQUEST, e.message) //todo find status dynamically??
@@ -122,12 +122,11 @@ class SamplesController {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     }
-    try{
-      sampleService.searchSample(sampleId)
+    if(null != sampleService.searchSample(sampleId)){
       sampleService.updateSampleStatus(sampleId, status)
       return HttpResponse.status(HttpStatus.CREATED, "Sample status updated.")
     }
-    catch(Exception e) {
+    else {
       return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
     }
   }

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import life.qbic.datamodel.services.Location
 import life.qbic.datamodel.services.Sample
 import life.qbic.datamodel.services.Status
+import life.qbic.db.NotFoundException
 import life.qbic.micronaututils.auth.Authentication
 import life.qbic.service.ISampleService
 
@@ -49,9 +50,9 @@ class SamplesController {
     if(!RegExValidator.isValidSampleCode(code)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
-      Sample s = sampleService.searchSample(code);
+      Sample s = sampleService.searchSample(code)
       if(s!=null) {
-        return HttpResponse.ok(s);
+        return HttpResponse.ok(s)
       } else {
         return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
       }
@@ -71,7 +72,12 @@ class SamplesController {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
-      return sampleService.addNewLocation(sampleId, location)
+      Location loc = sampleService.addNewLocation(sampleId, location)
+      if(loc!=null) {
+        return HttpResponse.ok(loc)
+      } else {
+        return HttpResponse.status(HttpStatus.BAD_REQUEST, "Could not add Sample to Location in the system!")
+      }
     }
   }
 
@@ -94,7 +100,12 @@ class SamplesController {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     } else {
-      return sampleService.updateLocation(sampleId, location)
+      Location loc = sampleService.updateLocation(sampleId, location)
+      if(loc!=null) {
+        return HttpResponse.ok(loc)
+      } else {
+        return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample and Location were not found in the system!")
+      }
     }
   }
 
@@ -111,14 +122,12 @@ class SamplesController {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
     }
-    boolean found = sampleService.searchSample(sampleId)!=null;
-    if(found) {
-      sampleService.updateSampleStatus(sampleId, status);
-      String msg = "Sample status updated."
-      HttpResponse response = HttpResponse.status(HttpStatus.CREATED, msg)
-      response.body(msg)
-      return response
-    } else {
+    try{
+      sampleService.searchSample(sampleId)
+      sampleService.updateSampleStatus(sampleId, status)
+      return HttpResponse.status(HttpStatus.CREATED, "Sample status updated.")
+    }
+    catch(NotFoundException notFoundException) {
       return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
     }
   }

--- a/src/main/groovy/life/qbic/controller/SamplesController.groovy
+++ b/src/main/groovy/life/qbic/controller/SamplesController.groovy
@@ -71,13 +71,12 @@ class SamplesController {
   HttpResponse<Location> newLocation(@PathVariable('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
-    } else {
-      Location loc = sampleService.addNewLocation(sampleId, location)
-      if(loc!=null) {
-        return HttpResponse.ok(loc)
-      } else {
+    }
+    try{
+      sampleService.addNewLocation(sampleId, location)
+      return HttpResponse.ok(location)
+    } catch(Exception e) {
         return HttpResponse.status(HttpStatus.BAD_REQUEST, "Could not add Sample to Location in the system!")
-      }
     }
   }
 
@@ -99,13 +98,13 @@ class SamplesController {
   HttpResponse<Location> updateLocation(@PathVariable('sampleId') String sampleId, Location location) {
     if(!RegExValidator.isValidSampleCode(sampleId)) {
       return HttpResponse.status(HttpStatus.BAD_REQUEST, "Not a valid sample code!")
-    } else {
-      Location loc = sampleService.updateLocation(sampleId, location)
-      if(loc!=null) {
-        return HttpResponse.ok(loc)
-      } else {
-        return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample and Location were not found in the system!")
-      }
+    }
+    try {
+      sampleService.updateLocation(sampleId, location)
+      return HttpResponse.ok(location)
+    }
+    catch(Exception e){
+      return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample and Location were not found in the system!")
     }
   }
 
@@ -127,7 +126,7 @@ class SamplesController {
       sampleService.updateSampleStatus(sampleId, status)
       return HttpResponse.status(HttpStatus.CREATED, "Sample status updated.")
     }
-    catch(NotFoundException notFoundException) {
+    catch(Exception e) {
       return HttpResponse.status(HttpStatus.NOT_FOUND, "Sample was not found in the system!")
     }
   }

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -59,8 +59,9 @@ interface IQueryService {
    * @param location Location object signifying the location of the sample
    * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
+   * @throws IllegalArgumentException when the sampleId or the location is not allowed
    */
-  void addNewLocation(String sampleId, Location location)
+  void addNewLocation(String sampleId, Location location) throws IllegalArgumentException
 
   /**
    * Updates or adds a new location for a provided sample code to the database, signifying an update to sample status or the
@@ -68,10 +69,10 @@ interface IQueryService {
    * The location object must exist in the database. The provided sample may or may not be at that location currently.
    * @param sampleId sample code
    * @param location Location object signifying the location of the sample
-   * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
+   * @throws IllegalArgumentException when the sampleId or the location is not allowed
    */
-  void updateLocation(String sampleId, Location location)
+  void updateLocation(String sampleId, Location location) throws IllegalArgumentException
 
   /**
    * Returns sample location, status and history information given a sample identifier

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -5,66 +5,69 @@ import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
 /**
- * //TODO describe this interface
+ * Interface for database queries
  */
 @Singleton
 interface IQueryService {
 
   /**
-   * //TODO describe intended method behaviour
-   * @param email
-   * @return TODO
-   * @since TODO
+   * Returns the contact using the provided email address
+   * @param email email address
+   * @return Contact object of the contact with the provided email address
+   * @since 1.0.0
    */
   Contact searchPersonByEmail(String email)
 
   /**
-   * //TODO describe intended method behaviour
-   * @return TODO
-   * @since TODO
+   * List all locations found in the database
+   * @return list of Location objects
+   * @since 1.0.0
    */
   List<Location> listLocations()
 
   /**
-   * //TODO describe intended method behaviour
-   * @param email
-   * @return TODO
-   * @since TODO
+   * List all locations attached to a person based on the the provided email
+   * @param email email address
+   * @return list of Location objects
+   * @since 1.0.0
    */
   List<Location> getLocationsForEmail(String email)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param location
-   * @return TODO
-   * @since TODO
+   * Adds a new location for a provided sample code to the database, signifying the forwarding of that sample to that location.
+   * The location object must exist in the database. The provided sample must not be at that location currently.
+   * @param sampleId sample code
+   * @param location Location object signifying the location of the sample
+   * @return HttpResponse signifying the success status of the performed action
+   * @since 1.0.0
    */
   HttpResponse addNewLocation(String sampleId, Location location)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param location
-   * @return TODO
-   * @since TODO
+   * Updates or adds a new location for a provided sample code to the database, signifying an update to sample status or the
+   * forwarding of that sample to that location.
+   * The location object must exist in the database. The provided sample may or may not be at that location currently.
+   * @param sampleId sample code
+   * @param location Location object signifying the location of the sample
+   * @return HttpResponse signifying the success status of the performed action
+   * @since 1.0.0
    */
   HttpResponse updateLocation(String sampleId, Location location)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @return TODO
-   * @since TODO
+   * Returns sample location, status and history information given a sample identifier
+   * @param sampleId the sample code of the sample in question
+   * @return Sample object containing history and current location and status of the sample
+   * @since 1.0.0
    */
   Sample searchSample(String sampleId)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param status
-   * @return TODO
-   * @since TODO
+   * Updates the status of a sample in the database without changing its location
+   * @param sampleId the sample code of the sample in question
+   * @param status a Status object denoting the status to be set for the provided sample
+   * @return boolean denoting if the update was successful
+   * @since 1.0.0
    */
   boolean updateSampleStatus(String sampleId, Status status)
 }

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -26,7 +26,7 @@ interface IQueryService {
   List<Location> listLocations()
 
   /**
-   * List all locations attached to a person based on the the provided email
+   * List all locations attached to a person based on the provided email
    * @param email email address
    * @return list of Location objects
    * @since 1.0.0

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -15,7 +15,10 @@ interface IQueryService {
    * @param email email address
    * @return Contact object of the contact with the provided email address
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and might be removed in the future.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   Contact searchPersonByEmail(String email)
 
   /**
@@ -30,8 +33,20 @@ interface IQueryService {
    * @param email email address
    * @return list of Location objects
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and will be removed in the future. {@link #getLocationsForPerson} should be used instead.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   List<Location> getLocationsForEmail(String email)
+
+  /**
+   * List all locations attached to a person with the provided identifier
+   * Currently one email address is used as identifier for a person in the system
+   * @param identifier the identifier for a person
+   * @return a list of locations for the given person, if the query was successful
+   * @since 1.1.0
+   */
+  List<Location> getLocationsForPerson(String identifier)
 
   /**
    * Adds a new location for a provided sample code to the database, signifying the forwarding of that sample to that location.

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -2,7 +2,8 @@ package life.qbic.db;
 
 import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
-import life.qbic.datamodel.services.*
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Interface for database queries

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -4,20 +4,67 @@ import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
+/**
+ * //TODO describe this interface
+ */
 @Singleton
 interface IQueryService {
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param email
+   * @return TODO
+   * @since TODO
+   */
   Contact searchPersonByEmail(String email)
-  
+
+  /**
+   * //TODO describe intended method behaviour
+   * @return TODO
+   * @since TODO
+   */
   List<Location> listLocations()
-  
+
+  /**
+   * //TODO describe intended method behaviour
+   * @param email
+   * @return TODO
+   * @since TODO
+   */
   List<Location> getLocationsForEmail(String email)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param location
+   * @return TODO
+   * @since TODO
+   */
   HttpResponse addNewLocation(String sampleId, Location location)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param location
+   * @return TODO
+   * @since TODO
+   */
   HttpResponse updateLocation(String sampleId, Location location)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @return TODO
+   * @since TODO
+   */
   Sample searchSample(String sampleId)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param status
+   * @return TODO
+   * @since TODO
+   */
   boolean updateSampleStatus(String sampleId, Status status)
 }

--- a/src/main/groovy/life/qbic/db/IQueryService.groovy
+++ b/src/main/groovy/life/qbic/db/IQueryService.groovy
@@ -56,7 +56,7 @@ interface IQueryService {
    * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  HttpResponse addNewLocation(String sampleId, Location location)
+  void addNewLocation(String sampleId, Location location)
 
   /**
    * Updates or adds a new location for a provided sample code to the database, signifying an update to sample status or the
@@ -67,7 +67,7 @@ interface IQueryService {
    * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  HttpResponse updateLocation(String sampleId, Location location)
+  void updateLocation(String sampleId, Location location)
 
   /**
    * Returns sample location, status and history information given a sample identifier
@@ -84,5 +84,5 @@ interface IQueryService {
    * @return boolean denoting if the update was successful
    * @since 1.0.0
    */
-  boolean updateSampleStatus(String sampleId, Status status)
+  void updateSampleStatus(String sampleId, Status status) throws NotFoundException
 }

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -5,6 +5,7 @@ import groovy.sql.Sql
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import life.qbic.datamodel.identifiers.SampleCodeFunctions
 import life.qbic.datamodel.people.Address
 import life.qbic.datamodel.people.Contact
 import life.qbic.datamodel.people.Person
@@ -37,70 +38,111 @@ class MariaDBManager implements IQueryService {
     this.dataSource = dataSource.getSource()
   }
 
-  void addNewLocation(String sampleId, Location location) {
+  void addNewLocation(String sampleId, Location location) throws IllegalArgumentException{
+
+    if (!SampleCodeFunctions.isQbicBarcode(sampleId) && !SampleCodeFunctions.isQbicEntityCode(sampleId)) {
+      throw new IllegalArgumentException("$sampleId is not valid.")
+    }
+
     Connection connection = Objects.requireNonNull(dataSource.getConnection(), "Connection must " +
             "not be null.")
     Sql sql = new Sql(connection)
-    HttpResponse response = HttpResponse.ok(location);
+    int locationId
+    int personId
+
+    try {
+      //validate location
+      locationId = getLocationIdFromName(location.getName(), sql);
+      personId = getPersonIdFromEmail(location.getResponsibleEmail(), sql)
+    } catch (Exception e) {
+      // only close in case of an exception appearing we need it later on
+      sql.close()
+      throw e
+    }
+
+    if (personId < 0) {
+      String msg = "User with email " + location.getResponsibleEmail() + " was not found."
+      log.error(msg)
+      sql.close()
+      throw new IllegalArgumentException(msg)
+    }
+
+    if (locationId < 0) {
+      String msg = "Location " + location.getName() + " was not found."
+      log.error(msg)
+      sql.close()
+      throw new IllegalArgumentException(msg)
+    }
+
     try {
       sql.withTransaction {
-        int personId = getPersonIdFromEmail(location.getResponsibleEmail(), sql)
-        if (personId == -1) {
-          String msg = "User with email " + location.getResponsibleEmail() + " was not found."
-          log.error(msg)
-          throw new NotFoundException(msg)
-        }
-        int locationId = getLocationIdFromName(location.getName(), sql);
-        if (locationId == -1) {
-          String msg = "Location " + location.getName() + " was not found."
-          log.error(msg)
-          throw new NotFoundException(msg)
-        }
-
         log.info "Set new sample location ${location} for sample ${sampleId}."
         setNewLocationAsCurrent(sampleId, personId, locationId, location, sql)
         addOrUpdateSample(sampleId, locationId, sql)
-
       }
-    } catch (Exception ex) {
-      String msg = ex.getMessage()
-      log.info msg+" Rolling back previous changes."
+    } catch(SQLException sqlException) {
+      // will always be thrown instead of an exception when withClosure is used
+      String message = sqlException.getMessage()
+      log.error(message)
+      log.debug(sqlException)
+      log.info(sqlException.message+" Rolling back previous changes.")
+      throw new RuntimeException("Could not add $sampleId to $location")
     } finally {
       sql.close()
     }
   }
 
-  void updateLocation(String sampleId, Location location) {
-    HttpResponse response = HttpResponse.ok(location)
+  void updateLocation(String sampleId, Location location) throws IllegalArgumentException{
+    if (!SampleCodeFunctions.isQbicBarcode(sampleId) && !SampleCodeFunctions.isQbicEntityCode(sampleId)) {
+      throw new IllegalArgumentException("$sampleId is not valid.")
+    }
+
     Connection connection = Objects.requireNonNull(dataSource.getConnection(), "Connection must " +
             "not be null.")
+
     Sql sql = new Sql(connection)
+    int personId
+    int locationId
+
+    try {
+      // validate location
+      locationId = getLocationIdFromName(location.getName(), sql)
+      personId = getPersonIdFromEmail(location.getResponsibleEmail(), sql)
+    } catch (Exception unexpected) {
+      String message = unexpected.getMessage()
+      log.error(message)
+      log.debug(unexpected)
+      // only close the connection in case of an exception. We need it later on.
+      sql.close()
+      throw new RuntimeException("Could not update $sampleId to $location")
+    }
+
+    if (personId < 0) {
+      String msg = "User with email " + location.getResponsibleEmail() + " was not found."
+      log.error(msg)
+      sql.close()
+      throw new IllegalArgumentException(msg)
+    }
+    if (locationId < 0) {
+      String msg = "Location " + location.getName() + " was not found."
+      log.error(msg)
+      sql.close()
+      throw new IllegalArgumentException(msg)
+    }
+
     try {
       sql.withTransaction {
-        int personId = getPersonIdFromEmail(location.getResponsibleEmail(), sql)
-
-        if (personId == -1) {
-          String msg = "User with email " + location.getResponsibleEmail() + " was not found."
-          throw new NotFoundException(msg)
-        }
-        int locationId = getLocationIdFromName(location.getName(), sql)
-        if (locationId == -1) {
-           String msg = "Location " + location.getName() + " was not found."
-          throw new NotFoundException(msg)
-        }
-        // Always set new location as current
         setNewLocationAsCurrent(sampleId, personId, locationId, location, sql)
-
-        // update sample table current location id OR create new row
         addOrUpdateSample(sampleId, locationId, sql)
-
       }
-    } catch(Exception ex) {
-      String msg = ex.getMessage()
-      log.info msg+" Rolling back previous changes."
-      response = HttpResponse.badRequest(msg)
-    }
-    finally {
+    } catch(SQLException sqlException) {
+      // will always be thrown instead of an exception when withClosure is used
+      String message = sqlException.getMessage()
+      log.error(message)
+      log.debug(sqlException)
+      log.info(sqlException.message+" Rolling back previous changes.")
+      throw new RuntimeException("Could not update $sampleId to $location")
+    } finally {
       sql.close()
     }
   }
@@ -457,7 +499,7 @@ class MariaDBManager implements IQueryService {
   }
 
   //TODO JavaDoc
-  void updateSampleStatus(String sampleId, Status status) {
+  void updateSampleStatus(String sampleId, Status status) throws NotFoundException {
     //    logger.info("Looking for user with email " + email + " in the DB");
     Connection connection = Objects.requireNonNull(dataSource.getConnection(), "Connection must " +
             "not be null.")
@@ -466,14 +508,22 @@ class MariaDBManager implements IQueryService {
     final String query = "SELECT * from samples WHERE UPPER(id) = UPPER('${sampleId}');"
     try {
       List<GroovyRowResult> results = sql.rows(query)
-      if( results.size() > 0 ) {
+      if (results.size() > 0) {
         GroovyRowResult rs = results.get(0)
         int locationID = rs.get("current_location_ID")
         setStatus(sampleId, locationID, status, sql)
+      } else {
+        throw new NotFoundException("Sample $sampleId could not be found in the database.")
       }
+    } catch (NotFoundException notFoundException) {
+      sql.close()
+      throw notFoundException
     } catch (SQLException e) {
+      log.error("Could not update sample status for $sampleId: $e.message")
+      log.debug("Could not update sample status for $sampleId: $e.message", e)
+      sql.close()
+      throw e
       //      logger.error("SQL operation unsuccessful: " + e.getMessage());
-      e.printStackTrace();
     } finally {
       sql.close()
     }
@@ -508,7 +558,7 @@ class MariaDBManager implements IQueryService {
   private int getPersonIdFromEmail(String email, Sql sql) {
     //    logger.info("Looking for user with email " + email + " in the DB");
     int res = -1;
-    final String query = "SELECT * from $PERSONS_TABLE WHERE UPPER(email) = UPPER('${email}') OR UPPER(email) = UPPER('${user_id}')";
+    final String query = "SELECT * from $PERSONS_TABLE WHERE UPPER(email) = UPPER('${email}') OR UPPER(user_id) = UPPER('${email}')";
     try {
       List<GroovyRowResult> results = sql.rows(query)
       if( results.size() > 0 ) {

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -244,7 +244,9 @@ class MariaDBManager implements IQueryService {
   private static Location parseLocationFromMap(Map input) {
     Collection<String> expectedKeys = ["name", "street", "zip_code", "country", "first_name", "last_name", "email"]
     for(String key: expectedKeys) {
-      if(!input.keySet().contains(key.toUpperCase())) {
+      // the contains key uses the same groovy magic that the get uses later on to extract the fields
+      // even though the keys in the keySet of the map are all upper case
+      if (!input.containsKey(key)) {
         throw new IllegalArgumentException ("The provided input did not provide the expected key $key.")
       }
     }

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -55,7 +55,7 @@ class MariaDBManager implements IQueryService {
 
       }
     } catch (Exception ex) {
-      throw ex
+      throw new Exception(ex.message+" Rolling back previous changes.")
     } finally {
       sql.close()
     }
@@ -83,9 +83,11 @@ class MariaDBManager implements IQueryService {
         addOrUpdateSample(sampleId, locationId, sql)
 
       }
-    } catch (Exception ex) {
-      throw ex
-    } finally {
+    }
+    catch(Exception ex){
+      throw new Exception(ex.message+" Rolling back previous changes.")
+    }
+    finally {
       sql.close()
     }
   }

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -6,7 +6,9 @@ import groovy.sql.Sql
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.QBiCDataSource
 
 import javax.inject.Inject

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -508,7 +508,7 @@ class MariaDBManager implements IQueryService {
   private int getPersonIdFromEmail(String email, Sql sql) {
     //    logger.info("Looking for user with email " + email + " in the DB");
     int res = -1;
-    final String query = "SELECT * from $PERSONS_TABLE WHERE UPPER(email) = UPPER('${email}')";
+    final String query = "SELECT * from $PERSONS_TABLE WHERE UPPER(email) = UPPER('${email}') OR UPPER(email) = UPPER('${user_id}')";
     try {
       List<GroovyRowResult> results = sql.rows(query)
       if( results.size() > 0 ) {

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -11,25 +11,25 @@ import life.qbic.datamodel.services.*
 interface ILocationService {
 
   /**
-   * //TODO describe intended method behaviour
-   * @param email
-   * @return TODO
-   * @since TODO
+   * Returns the contact using the provided email address
+   * @param email email address
+   * @return Contact object of the contact with the provided email address
+   * @since 1.0.0
    */
   Contact searchPersonByEmail(String email)
 
   /**
-   * //TODO describe intended method behaviour
-   * @return TODO
-   * @since TODO
+   * List all known locations irrespective of user or samples at that location
+   * @return list of Location objects
+   * @since 1.0.0
    */
   List<Location> listLocations()
 
   /**
-   * //TODO describe intended method behaviour
-   * @param email
-   * @return TODO
-   * @since TODO
+   * List all locations attached to a person based on the provided email
+   * @param email email address
+   * @return list of Location objects
+   * @since 1.0.0
    */
   List<Location> getLocationsForEmail(String email)
 }

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -15,7 +15,10 @@ interface ILocationService {
    * @param email email address
    * @return Contact object of the contact with the provided email address
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and might be removed in the future.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   Contact searchPersonByEmail(String email)
 
   /**
@@ -30,6 +33,18 @@ interface ILocationService {
    * @param email email address
    * @return list of Location objects
    * @since 1.0.0
+   * @deprecated As of version 1.1.0 this method should no longer be used and will be removed in the future. {@link #getLocationsForPerson} should be used instead.
    */
+  //@Deprecated(since="1.1.0", forRemoval=true) //TODO this can be enabled in Java 11
+  @Deprecated
   List<Location> getLocationsForEmail(String email)
+
+  /**
+   * List all locations attached to a person with the provided identifier.<br/>
+   * Currently one email address is used as identifier for a person in the system
+   * @param identifier the identifier for a person
+   * @return a list of locations found
+   * @since 1.1.0
+   */
+  List<Location> getLocationsForPerson(String identifier)
 }

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -5,7 +5,7 @@ import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
 /**
- * //TODO describe this interface
+ * Service interface to search location and contact information
  */
 @Singleton
 interface ILocationService {

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -2,7 +2,9 @@ package life.qbic.service;
 
 import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Service interface to search location and contact information

--- a/src/main/groovy/life/qbic/service/ILocationService.groovy
+++ b/src/main/groovy/life/qbic/service/ILocationService.groovy
@@ -4,12 +4,32 @@ import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
+/**
+ * //TODO describe this interface
+ */
 @Singleton
 interface ILocationService {
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param email
+   * @return TODO
+   * @since TODO
+   */
   Contact searchPersonByEmail(String email)
-  
+
+  /**
+   * //TODO describe intended method behaviour
+   * @return TODO
+   * @since TODO
+   */
   List<Location> listLocations()
-  
+
+  /**
+   * //TODO describe intended method behaviour
+   * @param email
+   * @return TODO
+   * @since TODO
+   */
   List<Location> getLocationsForEmail(String email)
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -11,37 +11,40 @@ import life.qbic.datamodel.services.*
 interface ISampleService {
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param location
-   * @return TODO
-   * @since TODO
+   * Adds a new location for a provided sample code, signifying the forwarding of that sample to that location.
+   * The location object must exist in the database. The provided sample must not be at that location currently.
+   * @param sampleId sample code
+   * @param location Location object signifying the location of the sample
+   * @return HttpResponse signifying the success status of the performed action
+   * @since 1.0.0
    */
   HttpResponse addNewLocation(String sampleId, Location location)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param location
-   * @return TODO
-   * @since TODO
+   * Updates or adds a new location for a provided sample code, signifying an update to sample status or the
+   * forwarding of that sample to that location.
+   * The location object must exist in the database. The provided sample may or may not be at that location currently.
+   * @param sampleId sample code
+   * @param location Location object signifying the location of the sample
+   * @return HttpResponse signifying the success status of the performed action
+   * @since 1.0.0
    */
   HttpResponse updateLocation(String sampleId, Location location)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @return TODO
-   * @since TODO
+   * Returns sample location, status and history information given a sample identifier
+   * @param sampleId the sample code of the sample in question
+   * @return Sample object containing history and current location and status of the sample
+   * @since 1.0.0
    */
   Sample searchSample(String sampleId)
 
   /**
-   * //TODO describe intended method behaviour
-   * @param sampleId
-   * @param status
-   * @return TODO
-   * @since TODO
+   * Updates the status of a sample without changing its location
+   * @param sampleId the sample code of the sample in question
+   * @param status a Status object denoting the status to be set for the provided sample
+   * @return boolean denoting if the update was successful
+   * @since 1.0.0
    */
   boolean updateSampleStatus(String sampleId, Status status)
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -16,10 +16,9 @@ interface ISampleService {
    * The location object must exist in the database. The provided sample must not be at that location currently.
    * @param sampleId sample code
    * @param location Location object signifying the location of the sample
-   * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  Location addNewLocation(String sampleId, Location location) throws NotFoundException
+  void addNewLocation(String sampleId, Location location)
 
   /**
    * Updates or adds a new location for a provided sample code, signifying an update to sample status or the
@@ -27,10 +26,9 @@ interface ISampleService {
    * The location object must exist in the database. The provided sample may or may not be at that location currently.
    * @param sampleId sample code
    * @param location Location object signifying the location of the sample
-   * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  Location updateLocation(String sampleId, Location location) throws NotFoundException
+  void updateLocation(String sampleId, Location location)
 
   /**
    * Returns sample location, status and history information given a sample identifier
@@ -44,8 +42,7 @@ interface ISampleService {
    * Updates the status of a sample without changing its location
    * @param sampleId the sample code of the sample in question
    * @param status a Status object denoting the status to be set for the provided sample
-   * @return boolean denoting if the update was successful
    * @since 1.0.0
    */
-   void updateSampleStatus(String sampleId, Status status) throws NotFoundException
+   void updateSampleStatus(String sampleId, Status status)
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -1,7 +1,8 @@
-package life.qbic.service;
+package life.qbic.service
+
+import life.qbic.db.NotFoundException;
 
 import javax.inject.Singleton
-import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
 /**
@@ -18,7 +19,7 @@ interface ISampleService {
    * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  HttpResponse addNewLocation(String sampleId, Location location)
+  Location addNewLocation(String sampleId, Location location) throws NotFoundException
 
   /**
    * Updates or adds a new location for a provided sample code, signifying an update to sample status or the
@@ -29,7 +30,7 @@ interface ISampleService {
    * @return HttpResponse signifying the success status of the performed action
    * @since 1.0.0
    */
-  HttpResponse updateLocation(String sampleId, Location location)
+  Location updateLocation(String sampleId, Location location) throws NotFoundException
 
   /**
    * Returns sample location, status and history information given a sample identifier
@@ -46,5 +47,5 @@ interface ISampleService {
    * @return boolean denoting if the update was successful
    * @since 1.0.0
    */
-  boolean updateSampleStatus(String sampleId, Status status)
+   void updateSampleStatus(String sampleId, Status status) throws NotFoundException
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -5,7 +5,7 @@ import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
 /**
- * //TODO describe this interface
+ * Service interface to search and update sample information
  */
 @Singleton
 interface ISampleService {

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -4,6 +4,7 @@ import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.samples.Location
 import life.qbic.datamodel.samples.Sample
 import life.qbic.datamodel.samples.Status
+import life.qbic.db.NotFoundException
 
 import javax.inject.Singleton
 
@@ -19,8 +20,9 @@ interface ISampleService {
    * @param sampleId sample code
    * @param location Location object signifying the location of the sample
    * @since 1.0.0
+   * @throws IllegalArgumentException when the location or sampleId is not allowed
    */
-  void addNewLocation(String sampleId, Location location)
+  void addNewLocation(String sampleId, Location location) throws IllegalArgumentException
 
   /**
    * Updates or adds a new location for a provided sample code, signifying an update to sample status or the
@@ -29,8 +31,9 @@ interface ISampleService {
    * @param sampleId sample code
    * @param location Location object signifying the location of the sample
    * @since 1.0.0
+   * @throws IllegalArgumentException when the location or sampleId is not allowed
    */
-  void updateLocation(String sampleId, Location location)
+  void updateLocation(String sampleId, Location location) throws IllegalArgumentException
 
   /**
    * Returns sample location, status and history information given a sample identifier
@@ -45,6 +48,7 @@ interface ISampleService {
    * @param sampleId the sample code of the sample in question
    * @param status a Status object denoting the status to be set for the provided sample
    * @since 1.0.0
+   * @throws NotFoundException in case the sampleId could not be found
    */
-   void updateSampleStatus(String sampleId, Status status)
+   void updateSampleStatus(String sampleId, Status status) throws NotFoundException
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -4,14 +4,44 @@ import javax.inject.Singleton
 import io.micronaut.http.HttpResponse
 import life.qbic.datamodel.services.*
 
+/**
+ * //TODO describe this interface
+ */
 @Singleton
 interface ISampleService {
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param location
+   * @return TODO
+   * @since TODO
+   */
   HttpResponse addNewLocation(String sampleId, Location location)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param location
+   * @return TODO
+   * @since TODO
+   */
   HttpResponse updateLocation(String sampleId, Location location)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @return TODO
+   * @since TODO
+   */
   Sample searchSample(String sampleId)
 
+  /**
+   * //TODO describe intended method behaviour
+   * @param sampleId
+   * @param status
+   * @return TODO
+   * @since TODO
+   */
   boolean updateSampleStatus(String sampleId, Status status)
 }

--- a/src/main/groovy/life/qbic/service/ISampleService.groovy
+++ b/src/main/groovy/life/qbic/service/ISampleService.groovy
@@ -3,7 +3,9 @@ package life.qbic.service
 import life.qbic.db.NotFoundException;
 
 import javax.inject.Singleton
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 /**
  * Service interface to search and update sample information

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -37,4 +37,10 @@ class LocationServiceCenter implements ILocationService {
     log.info "Listing all known locations for person with e-mail "+email
     return database.getLocationsForEmail(email);
   }
+
+  @Override
+  List<Location> getLocationsForPerson(String identifier) {
+    log.info "Listing all known locations for the person identified by $identifier"
+    return database.getLocationsForPerson(identifier)
+  }
 }

--- a/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/LocationServiceCenter.groovy
@@ -7,7 +7,9 @@ import javax.inject.Singleton
 
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Log4j2

--- a/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
@@ -6,6 +6,7 @@ import life.qbic.datamodel.samples.Location
 import life.qbic.datamodel.samples.Sample
 import life.qbic.datamodel.samples.Status
 import life.qbic.db.IQueryService
+import life.qbic.db.NotFoundException
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,13 +22,13 @@ class SampleServiceCenter implements ISampleService {
   }
 
   @Override
-  void addNewLocation(String sampleId, Location location) {
+  void addNewLocation(String sampleId, Location location) throws IllegalArgumentException {
     log.info "Adding new location "+location.name+" for sample "+sampleId
     database.addNewLocation(sampleId, location)
   }
 
   @Override
-  void updateLocation(String sampleId, Location location) {
+  void updateLocation(String sampleId, Location location) throws IllegalArgumentException {
     log.info "Updating location to "+location.name+" for sample "+sampleId
     database.updateLocation(sampleId, location)
   }
@@ -39,7 +40,7 @@ class SampleServiceCenter implements ISampleService {
   }
 
   @Override
-  void updateSampleStatus(String sampleId, Status status) {
+  void updateSampleStatus(String sampleId, Status status) throws NotFoundException{
     log.info "Updating sample status of "+sampleId+". The status will be changed to: "+status
     database.updateSampleStatus(sampleId, status)
   }

--- a/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
@@ -19,15 +19,15 @@ class SampleServiceCenter implements ISampleService {
   }
 
   @Override
-  HttpResponse addNewLocation(String sampleId, Location location) {
+  void addNewLocation(String sampleId, Location location) {
     log.info "Adding new location "+location.name+" for sample "+sampleId
-    return database.addNewLocation(sampleId, location)
+    database.addNewLocation(sampleId, location)
   }
 
   @Override
-  HttpResponse updateLocation(String sampleId, Location location) {
+  void updateLocation(String sampleId, Location location) {
     log.info "Updating location to "+location.name+" for sample "+sampleId
-    return database.updateLocation(sampleId, location)
+    database.updateLocation(sampleId, location)
   }
 
   @Override
@@ -37,8 +37,8 @@ class SampleServiceCenter implements ISampleService {
   }
 
   @Override
-  boolean updateSampleStatus(String sampleId, Status status) {
+  void updateSampleStatus(String sampleId, Status status) {
     log.info "Updating sample status of "+sampleId+". The status will be changed to: "+status
-    return database.updateSampleStatus(sampleId, status)
+    database.updateSampleStatus(sampleId, status)
   }
 }

--- a/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
+++ b/src/main/groovy/life/qbic/service/SampleServiceCenter.groovy
@@ -5,7 +5,9 @@ import javax.inject.Singleton
 
 import groovy.util.logging.Log4j2
 import io.micronaut.http.HttpResponse
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Singleton

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -144,10 +144,11 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testNonExistingContact() throws Exception {
-    String expectedReason = "Email address was not found in the system!"
+    String emailAddress = "ian.banks@limitingfactor.com"
+    String expectedReason = "Email address ${emailAddress} was not found in the system!"
     String reason
     HttpStatus status
-    HttpRequest request = HttpRequest.GET("/locations/contacts/ian.banks@limitingfactor.com").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/${emailAddress}").basicAuth("servicewriter", "123456!")
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException responseException) {
@@ -188,7 +189,8 @@ class LocationsControllerIntegrationTest {
 
   @Test
   void testMalformedContact() throws Exception {
-    HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
+    String invalidContact = "justreadtheinstructions"
+    HttpRequest request = HttpRequest.GET("/locations/contacts/${invalidContact}").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -197,7 +199,7 @@ class LocationsControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not a valid email address!", reason)
+    assertEquals("${invalidContact} is not a valid email address!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -210,12 +210,15 @@ class LocationsControllerIntegrationTest {
   @Test
   void testMalformedContact() throws Exception {
     HttpRequest request = HttpRequest.GET("/locations/contacts/justreadtheinstructions").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -197,7 +197,7 @@ class LocationsControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Bad Request", reason)
+    assertEquals("Not a valid email address!", reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -1,41 +1,20 @@
 package life.qbic.controller
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
-import io.micronaut.context.env.PropertySource
-import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.Get
-import io.micronaut.http.annotation.Post
-import io.micronaut.http.annotation.Put
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.RxHttpClient
-import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
-import life.qbic.db.MariaDBManager
 import life.qbic.helpers.DBTester
-
-import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.ResultSet
-import java.sql.Statement
-import javax.inject.Inject
-
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.AfterClass
-import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 
@@ -92,10 +71,10 @@ class LocationsControllerIntegrationTest {
     HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
-    assertEquals(arr.size(), 1)
+    assertEquals(1, arr.size())
     JSONObject json = arr.getJSONObject(0)
 
-    assertEquals(json.get("name"),affName)
+    assertEquals(affName, json.get("name"))
 
     db.removeLocationAndPerson(personID, locationID)
   }
@@ -123,7 +102,7 @@ class LocationsControllerIntegrationTest {
     HttpRequest request = HttpRequest.GET("/locations/"+user_id).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
-    assertEquals(arr.size(), 0)
+    assertEquals(0, arr.size())
     
     db.removePerson(personID)
   }
@@ -144,7 +123,7 @@ class LocationsControllerIntegrationTest {
     String body = client.toBlocking().retrieve(request)
     JSONArray arr = new JSONArray(body)
     println arr
-    assertEquals(arr.size(), 3)
+    assertEquals(3, arr.size())
     for(int i = 0; i<arr.size();i++) {
       JSONObject json = arr.getJSONObject(i)
       assert(locNames.contains(json.get("name")))
@@ -175,8 +154,8 @@ class LocationsControllerIntegrationTest {
       reason = responseException.getMessage()
       status = responseException.getStatus()
     }
-    assertEquals(status, HttpStatus.NOT_FOUND)
-    assertEquals(reason, expectedReason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
+    assertEquals(expectedReason, reason)
   }
 
   @Test
@@ -192,17 +171,17 @@ class LocationsControllerIntegrationTest {
     int personID = db.addPerson("Morat", first, last, email)
     int locationID = db.addLocationForPerson(affName, street, country, 0, personID)
 
-    HttpRequest request = HttpRequest.GET("/locations/contacts/"+email).basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.GET("/locations/contacts/" + email).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     assertNotNull(body)
-    assertEquals(json.get("full_name"),first+" "+last)
-    assertEquals(json.get("email"),email)
-    JSONObject address = json.get("address")
-    assertEquals(address.get("affiliation"),affName)
-    assertEquals(address.get("street"),street)
-    assertEquals(address.get("zip_code"),zip)
-    assertEquals(address.get("country"),country)
+    assertEquals(first + " " + last, json.get("full_name"))
+    assertEquals(email, json.get("email"))
+    JSONObject address = json.get("address") as JSONObject
+    assertEquals(affName, address.get("affiliation"))
+    assertEquals(street, address.get("street"))
+    assertEquals(zip, address.get("zip_code"))
+    assertEquals(country, address.get("country"))
 
     db.removeLocationAndPerson(personID, locationID)
   }
@@ -218,7 +197,7 @@ class LocationsControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerIntegrationTest.groovy
@@ -219,6 +219,6 @@ class LocationsControllerIntegrationTest {
       status = e.getStatus()
     }
     assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 }

--- a/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
@@ -2,9 +2,9 @@ package life.qbic.controller
 
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 import life.qbic.service.ILocationService
 import life.qbic.service.LocationServiceCenter

--- a/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerSpec.groovy
@@ -1,0 +1,74 @@
+package life.qbic.controller
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import life.qbic.datamodel.services.Address
+import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.services.Status
+import life.qbic.db.IQueryService
+import life.qbic.service.ILocationService
+import life.qbic.service.LocationServiceCenter
+import spock.lang.Specification
+
+/**
+ * This class tests some methods of the LocationsController
+ *
+ *
+ * @since: 1.1.0
+ */
+class LocationsControllerSpec extends Specification {
+
+
+    def "The locations endpoint retuns a correct number of locations"() {
+        given: "a user identifier"
+        String exampleUId = "test@qbic.de"
+
+        and: "a list of locations for these user identifiers"
+        Date date = new Date(new Date().getTime());
+        Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+        Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+        Location location1 = new Location(name: "Test Location 1", responsiblePerson: exampleUId, responsibleEmail: "example1", address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+        Location location2 = new Location(name: "Test Location 2", responsiblePerson: exampleUId, responsibleEmail: "example2", address: address2, status: Status.PROCESSING, arrivalDate: date, forwardDate: date)
+        Location location3 = new Location(name: "Test Location 3", responsiblePerson: exampleUId, responsibleEmail: "example2", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+        List<Location> locations = [location1, location2, location3]
+
+        and: "an ILocationService returning these locations"
+        ILocationService locationService = Mock(ILocationService, {
+            getLocationsForPerson(exampleUId) >> locations
+        })
+
+        and: "a LocationsController (under test) with this location service"
+        LocationsController locationsController = new LocationsController(locationService)
+
+        when: "the LocationsController is accessed through the /{user_id} endpoint"
+        HttpResponse response = locationsController.locations(exampleUId)
+
+        then: "the HttpResponse succeeds"
+        response.status() == HttpStatus.OK
+        and: "there is a body returned"
+        response.body.isPresent()
+        and: "the response returns a list of locations"
+        response.body() instanceof List<Location>
+        and: "the list is as expected"
+        response.body() == locations
+    }
+
+    def "The locations endpoint creates a BAD_REQUEST(400) response on missing user"() {
+        given: "a locationService throwing an IllegalArgumentException"
+        ILocationService locationService = Mock(ILocationService, {
+            getLocationsForPerson(_ as String) >> { throw new IllegalArgumentException() }
+        })
+
+        and: "a LocationsController (under test) with this location service"
+        LocationsController locationsController = new LocationsController(locationService)
+
+        when: "the LocationsController is accessed through the /{user_id} endpoint"
+        HttpResponse response = locationsController.locations(userId)
+
+        then: "the HttpResponse is a bad request"
+        response.status() == HttpStatus.BAD_REQUEST
+
+        where:
+        userId = "ThisIsAValidButNonExistingId"
+    }
+}

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -16,9 +16,9 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import life.qbic.controller.LocationsController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.helpers.QueryMock
 import life.qbic.service.LocationServiceCenter
 
@@ -58,9 +58,9 @@ class LocationsControllerTest {
     assertEquals(response.getStatus().getCode(),200)
     Contact c = response.body.orElse(null)
 
-    assertEquals(c.fullName,first+" "+last)
+    assertEquals(c.fullName, first+" "+last)
     assertEquals(c.email,email)
-    Address address = c.address
+    Address address = c.getAddress()
     assertEquals(address.affiliation,affName)
     assertEquals(address.street,street)
     assertEquals(address.zipCode,zip)

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -41,7 +41,7 @@ class LocationsControllerTest {
   @Test
   void testNonExistingContact() throws Exception {
     HttpResponse<Contact> response = locations.contacts("ian.banks@limitingfactor.com")
-    assertEquals(response.getStatus().getCode(),404)
+    assertEquals(404, response.getStatus().getCode())
   }
 
   @Test
@@ -76,16 +76,16 @@ class LocationsControllerTest {
   @Test
   void testLocationsMail() throws Exception {
     HttpResponse response = locations.locations("right@right.de")
-    assertEquals(response.getStatus().getCode(), 200)
+    assertEquals(200, response.getStatus().getCode())
     List<Location> loc = response.body.orElse(null)
-    assertEquals(loc.size(),1)
+    assertEquals(1, loc.size())
   }
   
-  @Test
-  void testMalformedLocationsMail() throws Exception {
-    HttpResponse response = locations.locations("justreadtheinstructions")
-    assertEquals(response.getStatus().getCode(), 400)
-  }
+//  @Test
+//  void testMalformedLocationsMail() throws Exception {
+//    HttpResponse response = locations.locations("justreadtheinstructions")
+//    assertEquals(response.getStatus().getCode(), 400)
+//  }
   
   @Test
   void testLocations() throws Exception {

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -57,17 +57,11 @@ class LocationsControllerTest {
   }
   
   @Test
-  void testLocationsMail() throws Exception {
+  void testAvailableLocations() throws Exception {
     HttpResponse response = locations.locations("right@right.de")
     assertEquals(200, response.getStatus().getCode())
     List<Location> loc = response.body.orElse(null)
     assertEquals(1, loc.size())
-  }
-  
-  @Test
-  void testMalformedLocationsMail() throws Exception {
-    HttpResponse response = locations.locations("justreadtheinstructions")
-    assertEquals(400, response.getStatus().getCode())
   }
   
   @Test

--- a/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/LocationsControllerTest.groovy
@@ -38,7 +38,7 @@ class LocationsControllerTest {
     String country = "Chiark"
 
     HttpResponse response = locations.contacts(email)
-    assertEquals(response.getStatus().getCode(),200)
+    assertEquals(200, response.getStatus().getCode())
     Contact c = response.body.orElse(null)
 
     assertEquals(c.fullName, first+" "+last)
@@ -53,7 +53,7 @@ class LocationsControllerTest {
   @Test
   void testMalformedContact() throws Exception {
     HttpResponse response = locations.contacts("justreadtheinstructions")
-    assertEquals(response.getStatus().getCode(), 400)
+    assertEquals(400, response.getStatus().getCode())
   }
   
   @Test
@@ -67,15 +67,15 @@ class LocationsControllerTest {
   @Test
   void testMalformedLocationsMail() throws Exception {
     HttpResponse response = locations.locations("justreadtheinstructions")
-    assertEquals(response.getStatus().getCode(), 400)
+    assertEquals(400, response.getStatus().getCode())
   }
   
   @Test
   void testLocations() throws Exception {
     HttpResponse response = locations.listLocations()
-    assertEquals(response.getStatus().getCode(), 200)
+    assertEquals(200, response.getStatus().getCode())
     List<Location> loc = response.body.orElse(null)
-    assertEquals(loc.size(),2)
+    assertEquals(2, loc.size())
   }
 
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -32,12 +32,12 @@ class SamplesControllerIntegrationTest {
 
   private static String existingLocation = "Existing Location"
   private static String existingPersonMail = "existing@mail.test"
-  private String validCode1 = "QABCD001A0";
-  private String validCode2 = "QABCD002A8";
-  private String validCode3 = "QABCD003A4";
-  private String validCode4 = "QABCD004AO";
-  private String validCode5 = "QABCD005AW";
-  private String validCode6 = "QABCD006A6";
+  private String validCode1 = "QSTTS024AX";
+  private String validCode2 = "QSTTS025A7";
+  private String validCode3 = "QSTTS016A8";
+  private String validCode4 = "QSTTS028AV";
+  private String validCode5 = "QSTTS029A5";
+  private String validCode6 = "QSTTS019AW";
   private String missingValidCode = "QABCD002ME";
   private String missingValidCode2 = "QAAAA001A8";
 
@@ -56,7 +56,6 @@ class SamplesControllerIntegrationTest {
 
     db = new DBTester();
     db.loginWithCredentials(driver, url, user, pw);
-
     db.createTables()
     db.addPerson("a", "b", "c", existingPersonMail)
     db.addLocation(existingLocation, "a", "b", 123)
@@ -274,13 +273,15 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "Location 4", country: "Germany", street: "Location 4 street", zipCode: 4)
     Location currentLocation = new Location(name: "Location 4", responsiblePerson: "Location 4 Person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
 
+    String statusString = "WAITING"
+    
     db.addSampleWithHistory(validCode2, currentLocation, currentPerson, new ArrayList<>(), new ArrayList<>())
-    HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
+    HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/"+statusString,"").basicAuth("servicewriter", "123456!")
 
     HttpResponse response  = client.toBlocking().exchange(request)
     //fixme is this expected to be 200 or 201 (created)?
     assertEquals(201, response.status.getCode())
-    assertEquals("Sample status updated to ${response.getStatus()}.".toString(), response.reason())
+    assertEquals("Sample status updated to ${statusString}.".toString(), response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
@@ -288,9 +289,11 @@ class SamplesControllerIntegrationTest {
     json = json.get("current_location")
     assertEquals(Status.WAITING.toString(), json.get("sample_status"));
 
-    request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","").basicAuth("servicewriter", "123456!")
+    statusString = "PROCESSED";
+    
+    request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/"+statusString,"").basicAuth("servicewriter", "123456!")
     response = client.toBlocking().exchange(request)
-    assertEquals("Sample status updated.", response.reason())
+    assertEquals("Sample status updated to ${statusString}.".toString(), response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
@@ -401,7 +404,6 @@ class SamplesControllerIntegrationTest {
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.METADATA_REGISTERED, arrivalDate: d);
     int locID = db.addLocation(location.name, adr.street, adr.country, adr.zipCode)
     db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email)
-    println location
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -55,7 +55,7 @@ class SamplesControllerIntegrationTest {
     db.loginWithCredentials(driver, url, user, pw);
 
     db.createTables()
-    db.addPerson("a", "b", "c", existingPersonMail, "0123")
+    db.addPerson("a", "b", "c", existingPersonMail)
     db.addLocation(existingLocation, "a", "b", 123)
   }
 
@@ -163,8 +163,8 @@ class SamplesControllerIntegrationTest {
     Location l1 = new Location(name: "Location 1", responsiblePerson: "Location 1 Person", responsibleEmail: email1, address: adr1, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
     Address adr2 = new Address(affiliation: "Location 2", country: "Germany", street: "Location 2 street", zipCode: 2)
     Location l2 = new Location(name: "Location 2", responsiblePerson: "Location 2 Person", responsibleEmail: email2, address: adr2, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
-    db.addPerson("u1","Location 1", "Person",email1,"123")
-    db.addPerson("u2","Location 2", "Person",email2,"456")
+    db.addPerson("u1","Location 1", "Person",email1)
+    db.addPerson("u2","Location 2", "Person",email2)
     db.addLocation(l1)
     db.addLocation(l2)
 
@@ -353,7 +353,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 1", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     int locID = db.addLocation(location.name, adr.street, adr.country, adr.zipCode)
-    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email, "123")
+    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email)
 
     HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
@@ -370,7 +370,7 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 1", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.METADATA_REGISTERED, arrivalDate: d);
     int locID = db.addLocation(location.name, adr.street, adr.country, adr.zipCode)
-    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email, "123")
+    db.addPerson("u", currentPerson.firstName, currentPerson.lastName, email)
     println location
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -82,8 +82,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
-    assertEquals(reason, "Bad Request")
+    assertEquals(HttpStatus.BAD_REQUEST, status)
+    assertEquals("Bad Request", reason)
   }
 
   @Test
@@ -95,7 +95,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.UNAUTHORIZED)
+    assertEquals(HttpStatus.UNAUTHORIZED, status)
   }
 
   @Test
@@ -127,9 +127,9 @@ class SamplesControllerIntegrationTest {
 
     Sample s = mapper.readValue(body, Sample.class);
     assertNotNull(s)
-    assertEquals(s.code,validCode1)
-    assertEquals(s.currentLocation,currentLocation)
-    assertEquals(s.pastLocations,pastLocations)
+    assertEquals(validCode1, s.code)
+    assertEquals(currentLocation, s.currentLocation)
+    assertEquals(pastLocations, s.pastLocations)
   }
 
   @Test void testReadSample() {
@@ -146,9 +146,9 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,"QTRAK005A9")
-      assertEquals(s.currentLocation,l1)
-      assertEquals(s.pastLocations,null)
+      assertEquals("QTRAK005A9", s.code)
+      assertEquals(l1, s.currentLocation)
+      assertEquals(null, s.pastLocations)
     }
   }
 
@@ -169,14 +169,14 @@ class SamplesControllerIntegrationTest {
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l1).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(response.status.getCode(), 200)
+      assertEquals(200, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
-      assertEquals(l1.address,testLocation.address)
-      assertEquals(l1.name,testLocation.name)
-      assertEquals(l1.status,testLocation.status)
-      assertEquals(l1.responsiblePerson,testLocation.responsiblePerson)
-      assertEquals(l1.responsibleEmail,testLocation.responsibleEmail)
+      assertEquals(l1.address, testLocation.address)
+      assertEquals(l1.name, testLocation.name)
+      assertEquals(l1.status, testLocation.status)
+      assertEquals(l1.responsiblePerson, testLocation.responsiblePerson)
+      assertEquals(l1.responsibleEmail, testLocation.responsibleEmail)
     }
 
     for(String code : codes) {
@@ -184,26 +184,26 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,code)
-      assertEquals(l1.address,s.currentLocation.address)
-      assertEquals(l1.name,s.currentLocation.name)
-      assertEquals(l1.status,s.currentLocation.status)
-      assertEquals(l1.responsiblePerson,s.currentLocation.responsiblePerson)
-      assertEquals(l1.responsibleEmail,s.currentLocation.responsibleEmail)
-      assertEquals(s.pastLocations,null)
+      assertEquals(code, s.code)
+      assertEquals(l1.address, s.currentLocation.address)
+      assertEquals(l1.name, s.currentLocation.name)
+      assertEquals(l1.status, s.currentLocation.status)
+      assertEquals(l1.responsiblePerson, s.currentLocation.responsiblePerson)
+      assertEquals(l1.responsibleEmail, s.currentLocation.responsibleEmail)
+      assertEquals(null, s.pastLocations)
     }
 
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l2).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(response.status.getCode(), 200)
+      assertEquals(200, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
-      assertEquals(l2.address,testLocation.address)
-      assertEquals(l2.name,testLocation.name)
-      assertEquals(l2.status,testLocation.status)
-      assertEquals(l2.responsiblePerson,testLocation.responsiblePerson)
-      assertEquals(l2.responsibleEmail,testLocation.responsibleEmail)
+      assertEquals(l2.address, testLocation.address)
+      assertEquals(l2.name, testLocation.name)
+      assertEquals(l2.status, testLocation.status)
+      assertEquals(l2.responsiblePerson, testLocation.responsiblePerson)
+      assertEquals(l2.responsibleEmail, testLocation.responsibleEmail)
     }
 
     for(String code : codes) {
@@ -211,13 +211,13 @@ class SamplesControllerIntegrationTest {
       String body = client.toBlocking().retrieve(request)
       Sample s = mapper.readValue(body, Sample.class);
       assertNotNull(s)
-      assertEquals(s.code,code)
+      assertEquals(code, s.code)
       assertEquals(l2.address,s.currentLocation.address)
       assertEquals(l2.name,s.currentLocation.name)
       assertEquals(l2.status,s.currentLocation.status)
       assertEquals(l2.responsiblePerson,s.currentLocation.responsiblePerson)
       assertEquals(l2.responsibleEmail,s.currentLocation.responsibleEmail)
-      assertEquals(s.pastLocations.size(),1)
+      assertEquals(1, s.pastLocations.size())
     }
   }
 
@@ -232,8 +232,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Not Found")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals("Not Found", reason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
 
@@ -249,8 +249,8 @@ class SamplesControllerIntegrationTest {
     reason = e.getMessage()
     status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -266,23 +266,23 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
-    assertEquals(body, "Sample status updated.")
+    assertEquals("Sample status updated.", body)
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     json = json.get("current_location")
-    assertEquals(json.get("sample_status"), Status.WAITING.toString());
+    assertEquals(Status.WAITING.toString(), json.get("sample_status"));
 
     request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","").basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
-    assertEquals(body, "Sample status updated.")
+    assertEquals("Sample status updated.", body)
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
     json = new JSONObject(body);
     json = json.get("current_location")
-    assertEquals(json.get("sample_status"), Status.PROCESSED.toString());
+    assertEquals(Status.PROCESSED.toString(), json.get("sample_status"));
   }
 
   @Test
@@ -318,8 +318,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Not Found")
-    assertEquals(status, HttpStatus.NOT_FOUND)
+    assertEquals("Not Found", reason)
+    assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
   @Test
@@ -338,8 +338,8 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals(reason, "Bad Request")
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals("Bad Request", reason)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
 
@@ -368,9 +368,9 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
     Location testLocation = db.searchSample(validCode4).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -386,10 +386,10 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
 
     Location testLocation = db.searchSample(missingValidCode2).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -402,20 +402,20 @@ class SamplesControllerIntegrationTest {
     db.addSampleWithHistory(validCode5, location, currentPerson, new ArrayList<>(), new ArrayList<>())
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode())
 
     Location testLocation = db.searchSample(validCode5).currentLocation
 
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
 
     d = new java.sql.Date(new Date().getTime());
     location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.PROCESSED, arrivalDate: d, forwardDate: d);
     request = HttpRequest.PUT("/samples/"+validCode5+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     response = client.toBlocking().exchange(request)
-    assertEquals(response.status.getCode(), 200)
+    assertEquals(200, response.status.getCode(), )
 
     testLocation = db.searchSample(validCode5).currentLocation
-    assertEquals(location,testLocation)
+    assertEquals(location, testLocation)
   }
 
   @Test
@@ -433,7 +433,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {          
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -451,7 +451,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {          
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -469,7 +469,7 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
   @Test
@@ -487,6 +487,6 @@ class SamplesControllerIntegrationTest {
     } catch (HttpClientResponseException e) {
       status = e.getStatus()
     }
-    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -1,25 +1,23 @@
 package life.qbic.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
-
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpStatus
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import life.qbic.datamodel.services.*
 import life.qbic.helpers.DBTester
-
 import org.json.JSONObject
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
+
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
-
-import com.fasterxml.jackson.databind.ObjectMapper
 
 class SamplesControllerIntegrationTest {
 
@@ -83,7 +81,7 @@ class SamplesControllerIntegrationTest {
       status = e.getStatus()
     }
     assertEquals(HttpStatus.BAD_REQUEST, status)
-    assertEquals("Bad Request", reason)
+    assertEquals("Not a valid sample code!", reason)
   }
 
   @Test
@@ -232,7 +230,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not Found", reason)
+    assertEquals("Sample was not found in the system!", reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
@@ -249,7 +247,7 @@ class SamplesControllerIntegrationTest {
     reason = e.getMessage()
     status = e.getStatus()
     }
-    assertEquals("Bad Request", reason)
+    assertEquals("Not a valid sample code!", reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
@@ -318,7 +316,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not Found", reason)
+    assertEquals("Sample was not found in the system!", reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
@@ -338,7 +336,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Bad Request", reason)
+    assertEquals("Not a valid sample code!", reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -279,7 +279,7 @@ class SamplesControllerIntegrationTest {
 
     HttpResponse response  = client.toBlocking().exchange(request)
     //fixme is this expected to be 200 or 201 (created)?
-    assertEquals(200, response.status.getCode())
+    assertEquals(201, response.status.getCode())
     assertEquals("Sample status updated to ${response.getStatus()}.".toString(), response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -4,6 +4,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
 
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
@@ -73,25 +74,28 @@ class SamplesControllerIntegrationTest {
   @Test
   void testMalformedSample() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/wrong").basicAuth("servicewriter", "123456!")
-    String error = "";
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage();
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
+    assertEquals(reason, "Bad Request")
   }
 
   @Test
   void testAuthenticationRequired() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/" + validCode1)
-    def statusCode
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      statusCode = e.getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(401, statusCode)
+    assertEquals(status, HttpStatus.UNAUTHORIZED)
   }
 
   @Test
@@ -126,12 +130,6 @@ class SamplesControllerIntegrationTest {
     assertEquals(s.code,validCode1)
     assertEquals(s.currentLocation,currentLocation)
     assertEquals(s.pastLocations,pastLocations)
-    //    JSONObject json = new JSONObject(body);
-    //
-    //    assertNotNull(body)
-    //    assertEquals(json.get("code"),validCode1)
-    //    assertEquals(json.get("current_location"),currentLocation)
-    //    assertEquals(json.get("past_locations"),pastLocations)
   }
 
   @Test void testReadSample() {
@@ -226,26 +224,33 @@ class SamplesControllerIntegrationTest {
   @Test
   void testMissingSample() throws Exception {
     HttpRequest request = HttpRequest.GET("/samples/"+missingValidCode).basicAuth("servicewriter", "123456!")
-    String error = "";
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Not Found")
+    assertEquals(reason, "Not Found")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 
 
   @Test
   void testStatusMalformedSample() throws Exception {
     HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+          
+    reason = e.getMessage()
+    status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -305,13 +310,16 @@ class SamplesControllerIntegrationTest {
   void testStatusNoSample() throws Exception {
     String code = "QNONE001AC"
     HttpRequest request = HttpRequest.PUT("/samples/"+code+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Not Found")
+    assertEquals(reason, "Not Found")
+    assertEquals(status, HttpStatus.NOT_FOUND)
   }
 
   @Test
@@ -322,13 +330,16 @@ class SamplesControllerIntegrationTest {
     Location location = new Location(name: "locname", responsiblePerson: "some person", responsibleEmail: "some@person.de", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
 
     HttpRequest request = HttpRequest.POST("/samples/"+malformedCode+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    String error = ""
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      error = e.getMessage()
+      reason = e.getMessage()
+      status = e.getStatus()
     }
-    assertEquals(error, "Bad Request")
+    assertEquals(reason, "Bad Request")
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
 
@@ -415,13 +426,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 2", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-    } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+    } catch (HttpClientResponseException e) {          
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -432,13 +444,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 3", zipCode: 213)
     Location location = new Location(name: "unknown", responsiblePerson: "some person", responsibleEmail: existingPersonMail, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-    } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+    } catch (HttpClientResponseException e) {          
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -449,13 +462,14 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 4", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.POST("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
     } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 
   @Test
@@ -466,13 +480,13 @@ class SamplesControllerIntegrationTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet 5", zipCode: 213)
     Location location = new Location(name: existingLocation, responsiblePerson: "some person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode6+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
-    int stat = -1
+    String reason
+    HttpStatus status
     try {
       HttpResponse response = client.toBlocking().exchange(request)
-      println response.getStatus()
     } catch (HttpClientResponseException e) {
-      stat =  e.getResponse().getStatus().code
+      status = e.getStatus()
     }
-    assertEquals(stat, 400)
+    assertEquals(status, HttpStatus.BAD_REQUEST)
   }
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -167,7 +167,7 @@ class SamplesControllerIntegrationTest {
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l1).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(200, response.status.getCode())
+      assertEquals(201, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
       assertEquals(l1.address, testLocation.address)
@@ -194,7 +194,7 @@ class SamplesControllerIntegrationTest {
     for(String code : codes) {
       HttpRequest request = HttpRequest.POST("/samples/"+code+"/currentLocation/", l2).basicAuth("servicewriter", "123456!")
       HttpResponse response = client.toBlocking().exchange(request)
-      assertEquals(200, response.status.getCode())
+      assertEquals(201, response.status.getCode())
 
       Location testLocation = db.searchSample(code).currentLocation
       assertEquals(l2.address, testLocation.address)
@@ -261,20 +261,21 @@ class SamplesControllerIntegrationTest {
     Location currentLocation = new Location(name: "Location 4", responsiblePerson: "Location 4 Person", responsibleEmail: email, address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
 
     db.addSampleWithHistory(validCode2, currentLocation, currentPerson, new ArrayList<>(), new ArrayList<>())
-
     HttpRequest request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
-    String body = client.toBlocking().retrieve(request)
-    assertEquals("Sample status updated.", body)
+
+    HttpResponse response  = client.toBlocking().exchange(request)
+    assertEquals(201, response.status.getCode())
+    assertEquals("Sample status updated.", response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
-    body = client.toBlocking().retrieve(request)
+    String body = client.toBlocking().retrieve(request)
     JSONObject json = new JSONObject(body);
     json = json.get("current_location")
     assertEquals(Status.WAITING.toString(), json.get("sample_status"));
 
     request = HttpRequest.PUT("/samples/"+validCode2+"/currentLocation/PROCESSED","").basicAuth("servicewriter", "123456!")
-    body = client.toBlocking().retrieve(request)
-    assertEquals("Sample status updated.", body)
+    response = client.toBlocking().exchange(request)
+    assertEquals("Sample status updated.", response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     body = client.toBlocking().retrieve(request)
@@ -366,7 +367,7 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+validCode4+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(200, response.status.getCode())
+    assertEquals(201, response.status.getCode())
     Location testLocation = db.searchSample(validCode4).currentLocation
     assertEquals(location, testLocation)
   }
@@ -384,7 +385,7 @@ class SamplesControllerIntegrationTest {
 
     HttpRequest request = HttpRequest.POST("/samples/"+missingValidCode2+"/currentLocation/", location).basicAuth("servicewriter", "123456!")
     HttpResponse response = client.toBlocking().exchange(request)
-    assertEquals(200, response.status.getCode())
+    assertEquals(201, response.status.getCode())
 
     Location testLocation = db.searchSample(missingValidCode2).currentLocation
     assertEquals(location, testLocation)

--- a/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerIntegrationTest.groovy
@@ -9,7 +9,9 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.helpers.DBTester
 import org.json.JSONObject
 import org.junit.AfterClass
@@ -71,7 +73,8 @@ class SamplesControllerIntegrationTest {
 
   @Test
   void testMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.GET("/samples/wrong").basicAuth("servicewriter", "123456!")
+    String malformedSample = "wrong"
+    HttpRequest request = HttpRequest.GET("/samples/${malformedSample}").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -81,7 +84,7 @@ class SamplesControllerIntegrationTest {
       status = e.getStatus()
     }
     assertEquals(HttpStatus.BAD_REQUEST, status)
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedSample} is not a valid sample identifier!".toString(), reason)
   }
 
   @Test
@@ -230,14 +233,15 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Sample was not found in the system!", reason)
+    assertEquals("Sample with ID ${missingValidCode} was not found in the system!".toString(), reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
 
   @Test
   void testStatusMalformedSample() throws Exception {
-    HttpRequest request = HttpRequest.PUT("/samples/wrong/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
+    String malformedSample = "wrong"
+    HttpRequest request = HttpRequest.PUT("/samples/${malformedSample}/currentLocation/WAITING","").basicAuth("servicewriter", "123456!")
     String reason
     HttpStatus status
     try {
@@ -247,7 +251,7 @@ class SamplesControllerIntegrationTest {
     reason = e.getMessage()
     status = e.getStatus()
     }
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedSample} is not a valid sample identifier!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 
@@ -265,7 +269,7 @@ class SamplesControllerIntegrationTest {
 
     HttpResponse response  = client.toBlocking().exchange(request)
     assertEquals(201, response.status.getCode())
-    assertEquals("Sample status updated.", response.reason())
+    assertEquals("Sample status updated to ${response.getStatus()}.".toString(), response.reason())
 
     request = HttpRequest.GET("/samples/"+validCode2).basicAuth("servicewriter", "123456!")
     String body = client.toBlocking().retrieve(request)
@@ -317,7 +321,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Sample was not found in the system!", reason)
+    assertEquals("Sample with ID ${code} was not found in the system!".toString(), reason)
     assertEquals(HttpStatus.NOT_FOUND, status)
   }
 
@@ -337,7 +341,7 @@ class SamplesControllerIntegrationTest {
       reason = e.getMessage()
       status = e.getStatus()
     }
-    assertEquals("Not a valid sample code!", reason)
+    assertEquals("${malformedCode} is not a valid sample identifier!".toString(), reason)
     assertEquals(HttpStatus.BAD_REQUEST, status)
   }
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -102,7 +102,7 @@ class SamplesControllerTest {
   }
 
   @Test
-  void MissingSampleNewLocation() throws Exception {
+  void testMissingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
@@ -110,7 +110,7 @@ class SamplesControllerTest {
     assertEquals(404, response.status.getCode())
   }
   @Test
-  void ExistingSampleNewLocation() throws Exception {
+  void testExistingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -16,10 +16,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import life.qbic.controller.SamplesController
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
 import life.qbic.db.IQueryService
 import life.qbic.helpers.QueryMock
 import life.qbic.service.ISampleService
@@ -30,6 +26,9 @@ import org.junit.BeforeClass
 import org.junit.Test
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 
 class SamplesControllerTest {
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -49,7 +49,7 @@ class SamplesControllerTest {
   @Test
   void testMalformedSample() throws Exception {
     HttpResponse response = samples.sample("wrong")
-    assertEquals(response.status.getCode(), 400)
+    assertEquals(400, response.status.getCode())
   }
 
   @Test
@@ -64,20 +64,20 @@ class SamplesControllerTest {
   @Test
   void testMissingSample() throws Exception {
     HttpResponse response = samples.sample(missingSampleCode);
-    assertEquals(response.getStatus().getCode(),404)
+    assertEquals(404, response.getStatus().getCode())
   }
 
 
   @Test
   void testStatusMalformedSample() throws Exception {
     HttpResponse response = samples.sampleStatus("", Status.PROCESSED)
-    assertEquals(response.getStatus().getCode(), 400)
+    assertEquals(400, response.getStatus().getCode())
   }
 
   @Test
   void testStatus() throws Exception {
     HttpResponse response = samples.sampleStatus(existingCode, Status.PROCESSED)
-    assertEquals(response.getStatus().getCode(), 201)
+    assertEquals(201, response.getStatus().getCode())
   }
 
   @Test
@@ -89,7 +89,7 @@ class SamplesControllerTest {
   @Test
   void testStatusNoSample() throws Exception {
     HttpResponse response = samples.sampleStatus(missingSampleCode, null)
-    assertEquals(response.status.getCode(), 404)
+    assertEquals(404, response.status.getCode())
   }
 
   @Test
@@ -98,7 +98,7 @@ class SamplesControllerTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation("x", location)
-    assertEquals(response.status.getCode(), 400)
+    assertEquals(400, response.status.getCode())
   }
 
   @Test
@@ -107,7 +107,7 @@ class SamplesControllerTest {
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation(validMissingCode, location)
-    assertEquals(response.status.getCode(), 201)
+    assertEquals(201, response.status.getCode())
   }
 
   @Test
@@ -117,6 +117,6 @@ class SamplesControllerTest {
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     samples.updateLocation(validMissingCode, location)
     HttpResponse response = samples.sampleStatus(validMissingCode, null)
-    assertEquals(response.status.getCode(), 404)
+    assertEquals(404, response.status.getCode())
   }
 }

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -102,11 +102,19 @@ class SamplesControllerTest {
   }
 
   @Test
-  void testSampleNewLocation() throws Exception {
+  void MissingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation(validMissingCode, location)
+    assertEquals(404, response.status.getCode())
+  }
+  @Test
+  void ExistingSampleNewLocation() throws Exception {
+    Date d = new java.sql.Date(new Date().getTime());
+    Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
+    Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
+    HttpResponse response = samples.newLocation(existingCode, location)
     assertEquals(201, response.status.getCode())
   }
 

--- a/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
+++ b/src/test/groovy/life/qbic/controller/SamplesControllerTest.groovy
@@ -86,22 +86,24 @@ class SamplesControllerTest {
     assertEquals(400, response.status.getCode())
   }
 
+  // sample is unknown, but valid and is added to first location
   @Test
   void testMissingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation(validMissingCode, location)
-    assertEquals(404, response.status.getCode())
+    assertEquals(200, response.status.getCode())
   }
-  //todo why do we expect different results here for the same code?
+
+  // sample exists and gets new location
   @Test
   void testExistingSampleNewLocation() throws Exception {
     Date d = new java.sql.Date(new Date().getTime());
     Address adr = new Address(affiliation: "locname", country: "Germany", street: "somestreet", zipCode: 213)
     Location location = new Location(name: "locname", responsiblePerson: "some person", address: adr, status: Status.WAITING, arrivalDate: d, forwardDate: d);
     HttpResponse response = samples.newLocation(existingCode, location)
-    assertEquals(201, response.status.getCode())
+    assertEquals(200, response.status.getCode())
   }
 
   @Test

--- a/src/test/groovy/life/qbic/helpers/DBTester.groovy
+++ b/src/test/groovy/life/qbic/helpers/DBTester.groovy
@@ -16,7 +16,9 @@ import javax.inject.Singleton
 
 import groovy.sql.ResultSetMetaDataWrapper
 import groovy.util.logging.Log4j2
+import life.qbic.datamodel.people.*
 import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.micronaututils.QBiCDataSource
 
 @Log4j2

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -29,14 +29,12 @@ import life.qbic.db.IQueryService
 @Requires(missingBeans=javax.sql.DataSource)
 class QueryMock implements IQueryService {
 
-  HttpResponse addNewLocation(String sampleId, Location location) {
-    HttpResponse<Location> response = HttpResponse.created(location)
-    return response
+  void addNewLocation(String sampleId, Location location) {
+    //no error is thrown
   }
 
-  HttpResponse<Location> updateLocation(String sampleId, Location location) {
-    HttpResponse<Location> response = HttpResponse.accepted()
-    return response
+  void updateLocation(String sampleId, Location location) {
+    //no error is thrown
   }
 
   Contact searchPersonByEmail(String email) {
@@ -68,8 +66,8 @@ class QueryMock implements IQueryService {
   }
 
 //  @Override
-  public boolean updateSampleStatus(String sampleId, Status status) {
-    return status!=null
+  void updateSampleStatus(String sampleId, Status status) {
+    //no error thrown
   }
 
   @Override

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -19,11 +19,9 @@ import java.util.regex.Matcher
 import javax.inject.Inject
 import javax.inject.Singleton
 
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Contact
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Sample
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 
 @Requires(missingBeans=javax.sql.DataSource)

--- a/src/test/groovy/life/qbic/helpers/QueryMock.groovy
+++ b/src/test/groovy/life/qbic/helpers/QueryMock.groovy
@@ -103,4 +103,24 @@ class QueryMock implements IQueryService {
     }
     return res;
   }
+
+  /**
+   * This mocked method provides some example locations for the given identifier
+   *
+   * @return an optional containing two example locations for a Dummy user with the provided identifier
+   * @InheritDoc
+   */
+  @Override  List<Location> getLocationsForPerson(String identifier) {
+    Date date = new java.sql.Date(new Date().getTime());
+    String responsiblePerson = "Dummy"
+
+    Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+    Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+    Location location1 = new Location(name: "Test Location 1", responsiblePerson: responsiblePerson, responsibleEmail: identifier, address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+
+    List<Location> locations = new ArrayList<>()
+    locations.add(location1)
+
+    return locations;
+  }
 }

--- a/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
+++ b/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
@@ -1,0 +1,47 @@
+package life.qbic.service
+
+import life.qbic.datamodel.services.Address
+import life.qbic.datamodel.services.Location
+import life.qbic.datamodel.services.Status
+import life.qbic.db.IQueryService
+import spock.lang.Specification
+
+/**
+ * Specifies how the LocationServiceCenter should behave
+ *
+ * @since: 1.1.0
+ */
+class LocationServiceCenterSpec extends Specification {
+
+
+    def "GetLocationsForPerson returns locations from IQueryService"() {
+        given: "a user identifier"
+        String userId = "test@qbic.de"
+
+        and: "a list of locations for the id"
+        Date date = new Date(new Date().getTime());
+        Address address1 = new Address(affiliation: "Gevantsa", country: "Chiark", street: "Hassease", zipCode: 0)
+        Address address2 = new Address(affiliation: "QBiC", country: "Germany", street: "Morgenstelle 10", zipCode: 72076)
+        Location location1 = new Location(name: "Test Location 1", responsiblePerson: userId, responsibleEmail: "example1", address: address1, status: Status.WAITING, arrivalDate: date, forwardDate: date)
+        Location location2 = new Location(name: "Test Location 2", responsiblePerson: userId, responsibleEmail: "example2", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+        Location location3 = new Location(name: "Test Location 3", responsiblePerson: userId, responsibleEmail: "example3", address: address2, status: Status.PROCESSED, arrivalDate: date, forwardDate: date)
+
+        List<Location> locations = [location1, location2, location3]
+
+        and: "an IQueryService returning these locations"
+        IQueryService queryService = Mock(IQueryService, {
+            getLocationsForPerson(userId) >> locations
+        })
+
+        and: "a LocationServiceCenter with this queryService"
+        ILocationService locationService = new LocationServiceCenter(queryService)
+
+        when: "the LocationServiceCenter is asked to supply the locations for a given person"
+        List<Location> result = locationService.getLocationsForPerson(userId)
+
+        then: "the resulting list should contain all locations for the provided person"
+        result.size() == 3
+        and: "the content should be as expected"
+        result == locations
+    }
+}

--- a/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
+++ b/src/test/groovy/life/qbic/service/LocationServiceCenterSpec.groovy
@@ -1,8 +1,8 @@
 package life.qbic.service
 
-import life.qbic.datamodel.services.Address
-import life.qbic.datamodel.services.Location
-import life.qbic.datamodel.services.Status
+import life.qbic.datamodel.people.*
+import life.qbic.datamodel.services.*
+import life.qbic.datamodel.samples.*
 import life.qbic.db.IQueryService
 import spock.lang.Specification
 


### PR DESCRIPTION
## 1.1.0
- Add missing JavaDoc (Issue #15)
- the `/{email}` endpoint now searches by the newly introduced `user_id` instead.
  This is no change in the behaviour as of now since they are identical as of now.
- HttpResponses now contain the error messages in the status reason
  instead of the response body