### PR TITLE
Clean up Pom.xml to make service work again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<outputFile>./target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</outputFile>
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -316,7 +317,6 @@
 								</transformer>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-
 								<transformer implementation="org.apache.maven.plugins.shade.resource.GroovyResourceTransformer">
 									<extModuleName>the-aggregated-module</extModuleName>
 									<extModuleVersion>1.0.0</extModuleVersion>


### PR DESCRIPTION
**Description of changes**
Restructures the Dependencies in the `pom.xml` to follow the more current guidelines: 
1.) Inclusion and referring of `groovy-bom` dependency in the `dependency-management` section to avoid unnecessary versioning of individual groovy dependencies
2.) Same for Micronaut dependencies through the inclusion of the `micronaut-bom` dependency
3.) Addition of `Maven shade plugin`, which is necessary to generate a fat jar including the correct `manifest.xml` file and dependencies for the service to run
4.) Adapt `Maven shade plugin` to follow the naming schema set by the `maven assembly plugin` in other projects leading to the generation of the `sampletracking-1.2.0.jar` without dependencies and the `sampletracking-1.2.0-jar-with-dependencies.jar `
5.) Updating dependency version to the most current version for direct dependencies(e.g. data-model-lib) ensuring that the versioning change doesn't break the service. 