### PR TITLE
Remove shade plugin from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,32 +311,40 @@
 					<includes>**/*Test.*</includes>
 				</configuration>
 			</plugin>
+			<!--Instructs maven to create a fat jar containing the manifest.xml file during packaging phase -->
 			<plugin>
-				<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin -->
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.1</version>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
+						<id>create-executable-jar</id>
 						<phase>package</phase>
 						<goals>
-							<goal>shade</goal>
+							<goal>single</goal>
 						</goals>
 						<configuration>
-							<outputFile>./target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</outputFile>
-							<transformers>
-								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>${exec.mainClass}</mainClass>
-								</transformer>
-								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.GroovyResourceTransformer">
-									<extModuleName>the-aggregated-module</extModuleName>
-									<extModuleVersion>1.0.0</extModuleVersion>
-								</transformer>
-							</transformers>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+							<archive>
+								<manifest>
+									<mainClass>life.qbic.SampleTracking</mainClass>
+								</manifest>
+							</archive>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--This disables the building of the default jar without dependencies-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>default-jar</id>
+						<phase>none</phase>
 					</execution>
 				</executions>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -80,24 +80,12 @@
 			<name>QBiC Releases</name>
 			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
 		</repository>
+		<!-- Host the everit json schema dependency -->
 		<repository>
-			<id>jcenter.bintray.com</id>
-			<url>https://jcenter.bintray.com</url>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 		</repository>
 	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>bintray</id>
-			<name>Groovy Bintray</name>
-			<url>https://dl.bintray.com/groovy/maven</url>
-			<releases>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
**Description of changes**
Removes the `maven shade plugin` and replaces it with the correct goal in the package phase specified via the `maven assembly plugin`.
This will create a singular jar in the target folder (the fat jar including dependencies) called 
`sampletracking-1.2.4-jar-with-dependencies.jar` containing the `manifest.xml` file. 