### PR TITLE
Adjust release action to master branch

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -89,5 +89,5 @@ jobs:
             await github.request(`POST /repos/${{ github.repository }}/pulls`, {
               title: 'Update version to ${{ github.event.inputs.versionTag }}',
               head: 'release/set-version-to-${{ github.event.inputs.versionTag }}',
-              base: 'main'
+              base: 'master'
             });


### PR DESCRIPTION
Changes the base branch for the version bump from `main` to `master`