### PR TITLE
Rename Github workflow jobs

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -3,7 +3,7 @@ name: Build Maven Package
 on: [ push ]
 
 jobs:
-  build:
+  package:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,4 +1,4 @@
-name: Build Maven Package
+name: "Build Maven Package"
 
 on: [ push ]
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,4 +1,4 @@
-name: "Build_Maven_Package"
+name: "Build Maven Package"
 
 on: [ push ]
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,4 +1,4 @@
-name: "Build Maven Package"
+name: "Build_Maven_Package"
 
 on: [ push ]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: "Create Release"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, edited ]
 
 jobs:
-  build:
+  label:
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v3

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Label Pull Requests
+name: "Label Pull Requests"
 
 on:
   pull_request:

--- a/.github/workflows/nexus-publish-snapshots.yml
+++ b/.github/workflows/nexus-publish-snapshots.yml
@@ -10,7 +10,7 @@ on:
       - development
 
 jobs:
-  build:
+  publish_snapshot:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/nexus-publish-snapshots.yml
+++ b/.github/workflows/nexus-publish-snapshots.yml
@@ -2,7 +2,7 @@
 # qbic-repo.qbic.uni-tuebingen.de packages when a release is created
 # For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
 
-name: Deploy Snapshot
+name: "Deploy Snapshot"
 
 on:
   push:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,7 +3,7 @@ name: Run Maven Tests
 on: [ push ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Run Maven Tests
+name: "Run Maven Tests"
 
 on: [ push ]
 


### PR DESCRIPTION
This PR provides declarative names for the workflow jobs, so we can use them for branch protection rules.