### PR TITLE
Introduce retry to connect to db server after time-out

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>2.7.3</version>
+			<version>3.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/groovy/life/qbic/DataSource.groovy
+++ b/src/main/groovy/life/qbic/DataSource.groovy
@@ -20,6 +20,7 @@ interface DataSource {
      * execution of the connection object with a try-with-resource statement or call the
      * {@link AutoCloseable#close()} method explicitly.</p>
      * @return a connection to the datasource
+     * @throws {@link TimeOutException} when a connection cannot be acquired from the data source
      */
-    Connection getConnection()
+    Connection getConnection() throws TimeOutException
 }

--- a/src/main/groovy/life/qbic/QBiCDataSource.groovy
+++ b/src/main/groovy/life/qbic/QBiCDataSource.groovy
@@ -20,7 +20,7 @@ class QBiCDataSource implements DataSource {
 
     private final static int MAX_RETRY_COUNT = 3
 
-    javax.sql.DataSource source
+    private final javax.sql.DataSource source
 
     @Inject
     QBiCDataSource(javax.sql.DataSource source) {
@@ -36,7 +36,7 @@ class QBiCDataSource implements DataSource {
         int turn = 1
         while (!connection) {
             if (turn == MAX_RETRY_COUNT) {
-                throw new TimeOutException("Maximum number of tries reached, connection to database server timed out repeatedly.")
+                throw new TimeOutException("Maximum number of tries reached ($MAX_RETRY_COUNT), connection to database server timed out repeatedly.")
             }
             try {
                 connection = this.source.getConnection()

--- a/src/main/groovy/life/qbic/TimeOutException.java
+++ b/src/main/groovy/life/qbic/TimeOutException.java
@@ -1,0 +1,22 @@
+package life.qbic;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public class TimeOutException extends RuntimeException {
+
+  public TimeOutException() {}
+
+  public TimeOutException(String message) {
+    super(message);
+  }
+
+  public TimeOutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/src/main/groovy/life/qbic/TimeOutException.java
+++ b/src/main/groovy/life/qbic/TimeOutException.java
@@ -1,15 +1,16 @@
 package life.qbic;
 
 /**
- * <b><class short description - 1 Line!></b>
+ * Timeout Exception
+ * <p>
+ * Is thrown when connections to a data source cannot be established.
  *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * @since 2.2.3
  */
 public class TimeOutException extends RuntimeException {
 
-  public TimeOutException() {}
+  public TimeOutException() {
+  }
 
   public TimeOutException(String message) {
     super(message);

--- a/src/main/groovy/life/qbic/db/MariaDBManager.groovy
+++ b/src/main/groovy/life/qbic/db/MariaDBManager.groovy
@@ -3,7 +3,9 @@ package life.qbic.db
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 import groovy.util.logging.Log4j2
+import life.qbic.DataSource
 import life.qbic.QBiCDataSource
+import life.qbic.TimeOutException
 import life.qbic.api.rest.v2.samples.SampleStatusDto
 import life.qbic.datamodel.identifiers.SampleCodeFunctions
 import life.qbic.datamodel.people.Address
@@ -27,7 +29,6 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import javax.sql.DataSource
 import java.sql.Connection
 import java.sql.SQLException
 import java.sql.Timestamp
@@ -49,7 +50,15 @@ class MariaDBManager implements IQueryService, INotificationService, SampleEvent
 
   @Inject
   MariaDBManager(QBiCDataSource dataSource) {
-    this.dataSource = dataSource.getSource()
+    this.dataSource = dataSource
+  }
+
+  private Connection getConnection() throws UnrecoverableException {
+    try {
+      return dataSource.getConnection()
+    } catch (TimeOutException exception) {
+      throw new UnrecoverableException("Connection to data source timed out", exception)
+    }
   }
 
   void addNewLocation(String sampleId, Location location) throws IllegalArgumentException {


### PR DESCRIPTION
Introduces a retry implementation with a default retry count of 3.

If the connection to the database server cannot be established the first time, 2 additional attempts
will be tried before a TimeOutException will be thrown!