### PR TITLE
Use dependency org.hsqldb with jdk8 classifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>2.7.1</version>
+			<classifier>jdk8</classifier>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.json/json -->
 		<dependency>


### PR DESCRIPTION
This is necessary so that the bytecode version matches the one of jdk8. If we do not do this, execution with jdk8 is no longer possible.